### PR TITLE
Refactor repository for readability and re-instantiation of all contracts 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,12 @@ deployedAddress.json
 bin/
 .embark/* 
 chains.json  
-test/helpers/testConstant.js 
-.gitignore
+test/helpers/testConstant.js  
+config/communication.js 
+config/namesystem.js 
+config/storage.js 
+config/webserver.js 
+app/* 
+config/blockchain.js 
+config/development/* 
+config/testnet/* 

--- a/test/AdditionalTokens.js
+++ b/test/AdditionalTokens.js
@@ -7,12 +7,12 @@ const testConstant = require('./helpers/testConstant');
 const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
-let userAddress = allAccounts[0];
-let recipientAddress = allAccounts[1];
-let signerAddress = allAccounts[2]; 
-let nonParticipantAddress = allAccounts[3];
+const userAddress = allAccounts[0];
+const recipientAddress = allAccounts[1];
+const signerAddress = allAccounts[2]; 
+const nonParticipantAddress = allAccounts[3];
 const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
-var nonce = 1;
+let nonce = 1;
 
 contract("Additional Token Tests", function () {
     beforeEach((done) => {
@@ -43,7 +43,6 @@ contract("Additional Token Tests", function () {
                 MultiLibrary: {
                     args: [
                         '$ERC20Token',
-                        '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
                         signerAddress,
                         recipientAddress,
                         timeout,
@@ -132,7 +131,7 @@ contract("Additional Token Tests", function () {
             from: nonParticipantAddress
         });
 
-        amount = 0;
+        let amount = 0;
         const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address, nonce, amount, MultiChannel.address, signersPk);
 
         try {
@@ -147,7 +146,7 @@ contract("Additional Token Tests", function () {
 
     it("Recipient Address cannot close an uninitialized channel", async () => {
 
-        amount = 0;
+        let amount = 0;
         const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address, nonce, amount, MultiChannel.address, signersPk);
 
         try {
@@ -162,7 +161,7 @@ contract("Additional Token Tests", function () {
 
     it("User cannot settle an uninitialized channel", async () => {
 
-        amount = 0;
+        let amount = 0;
         const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address, nonce, amount, MultiChannel.address, signersPk);
 
         try {
@@ -177,7 +176,7 @@ contract("Additional Token Tests", function () {
 
     it("Recipient Address cannot settle an uninitialized channel", async () => {
 
-        amount = 0;
+        let amount = 0;
         const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address, nonce, amount, MultiChannel.address, signersPk);
 
         try {

--- a/test/AdditionalTokens.js
+++ b/test/AdditionalTokens.js
@@ -1,212 +1,194 @@
-
 const MultiChannel = require('Embark/contracts/MultiChannel');
 const ERC20Token = require('Embark/contracts/ERC20Token');
 const MultiLibrary = require('Embark/contracts/MultiLibrary');
-const indexes = require('./helpers/ChannelDataIndexes.js')
-const StandardToken = require('Embark/contracts/StandardToken.sol');
-const Token = require('Embark/contracts/Token.sol');
 const closingHelper = require('./helpers/channelClosingHelper');
 const assertRevert = require('./helpers/assertRevert');
 const testConstant = require('./helpers/testConstant');
-const allAccounts = testConstant.ACCOUNTS; 
+const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
+let userAddress = allAccounts[0];
+let recipientAddress = allAccounts[1];
+let signerAddress = allAccounts[2];
+let nonParticipantAddress = allAccounts[3];
 
 config({
     "deployment": {
-        "accounts": [
-            {
-                "mnemonic":testConstant.MNEMONIC,
-                "numAddresses":testConstant.NUM_ADDRESS,
-                "addressIndex": testConstant.INDEX,
-                "hdpath":testConstant.PATH
-            }
-        ]},
-        contracts: {
-            "Token": {
+        "accounts": [{
+            "mnemonic": testConstant.MNEMONIC,
+            "numAddresses": testConstant.NUM_ADDRESS,
+            "addressIndex": testConstant.INDEX,
+            "hdpath": testConstant.PATH
+        }]
+    },
+    contracts: {
+        "Token": {
 
-            },
-            "StandardToken": {
+        },
+        "StandardToken": {
 
-            },
-            "WETHToken": {
-                args:[initialCreation, "WETH", 18, "STK"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ThingToken": {
-                args:[initialCreation, "Thing", 18, "THG"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ERC20Token": {
-                args: [initialCreation,'STK', 18, 'STK'],
-                "from": allAccounts[3]
-            },
-            MultiLibrary: {
-                args: [
-                    '$ERC20Token',
-                    '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
-                    allAccounts[2],
-                    allAccounts[1],
-                    timeout,
-                    1,
-                    0,
-                    0
-                ],
-                "fromIndex":1
-            },
-            "MultiChannel": {
-                args: [
-                    allAccounts[0],
-                    allAccounts[2],
-                    '$ERC20Token',
-                    timeout
-                ],
-                "from": allAccounts[1]
-            }
+        },
+        "WETHToken": {
+            args: [initialCreation, "WETH", 18, "STK"],
+            "instanceOf": "ERC20Token",
+            "from": nonParticipantAddress
+        },
+        "ThingToken": {
+            args: [initialCreation, "Thing", 18, "THG"],
+            "instanceOf": "ERC20Token",
+            "from": nonParticipantAddress
+        },
+        "ERC20Token": {
+            args: [initialCreation, 'STK', 18, 'STK'],
+            "from": nonParticipantAddress
+        },
+        MultiLibrary: {
+            args: [
+                '$ERC20Token',
+                '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
+                signerAddress,
+                recipientAddress,
+                timeout,
+                1,
+                0,
+                0
+            ],
+            "fromIndex": 1
+        },
+        "MultiChannel": {
+            args: [
+                userAddress,
+                signerAddress,
+                '$ERC20Token',
+                timeout
+            ],
+            "from": recipientAddress
+        }
+    }
+});
+
+contract("Testing Users Adding Other Tokens", function () {
+    this.timeout(0);
+    const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
+    var nonce = 1;
+
+    it("Non channel participant should not be able to add tokens", async () => {
+        try {
+            await MultiChannel.methods.addChannel(WETHToken.options.address, userAddress, recipientAddress, 10).send({
+                from: nonParticipantAddress
+            })
+            assert.fail("Non channel participant should never be able to add tokens");
+        } catch (error) {
+            assertRevert(error);
+        }
+    })
+
+    it("User should not be able to add tokens", async () => {
+        try {
+            await MultiChannel.methods.addChannel(WETHToken.options.address, userAddress, recipientAddress, 10).send({
+                from: userAddress
+            })
+            assert.fail("User should never be able to add tokens");
+        } catch (error) {
+            assertRevert(error);
+        }
+    })
+
+    it("Recipient Address should be able to add tokens", async () => {
+        await MultiChannel.methods.addChannel(WETHToken.options.address, userAddress, recipientAddress, 10).send({
+            from: recipientAddress
+        });
+        assert("Recipient Address should be able to add tokens");
+
+    })
+
+    it("User should not be able to add duplicate tokens", async () => {
+        try {
+            await MultiChannel.methods.addChannel(ThingToken.options.address, userAddress, recipientAddress, 10).send({
+                from: userAddress
+            })
+            assert.fail("User should never be able to add duplicate tokens");
+        } catch (error) {
+            assertRevert(error);
+        }
+    })
+
+    it("Recipient Address should not be able to add duplicate tokens", async () => {
+        try {
+            await MultiChannel.methods.addChannel(ThingToken.options.address, userAddress, recipientAddress, 10).send({
+                from: recipientAddress
+            })
+            assert.fail("Recipient Address should never be able to add duplicate tokens");
+        } catch (error) {
+            assertRevert(error);
+        }
+    })
+
+    it("User cannot close an uninitialized channel", async () => {
+        const transfer = 50;
+        await ThingToken.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        await ThingToken.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+
+        amount = 0;
+        const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.close(ThingToken.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: userAddress
+            });
+            assert.fail("User cannot close with amount greater than escrow");
+        } catch (error) {
+            assertRevert(error);
         }
     });
 
-    contract("Testing Users Adding Other Tokens", function () {
-        this.timeout(0);
-        let userAddress = allAccounts[0]; 
-        let recipientAddress= allAccounts[1]; 
-        let signerAddress = allAccounts[2]; 
-        const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
-        const userPk = Buffer.from(testConstant.USER_PK,'hex');
-        const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-        const recipientAddressPk = Buffer.from(testConstant.RECIPIENT_PK,'hex');
-        var nonce = 1;
-        
-        it ("Non channel participant should not be able to add tokens", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.addChannel(WETHToken.options.address,userAddress,recipientAddress,10).send({from:address[5]})
-                assert.fail("Non channel participant should never be able to add tokens");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        })
+    it("Recipient Address cannot close an uninitialized channel", async () => {
 
-        it ("User should not be able to add tokens", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.addChannel(WETHToken.options.address,userAddress,recipientAddress,10).send({from:userAddress})
-                assert.fail("User should never be able to add tokens");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        })
+        amount = 0;
+        const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address, nonce, amount, MultiChannel.address, signersPk);
 
-        it ("Recipient Address should be able to add tokens", async() =>
-        {
-            await MultiChannel.methods.addChannel(WETHToken.options.address,userAddress,recipientAddress,10).send({from:recipientAddress});
-            assert("Recipient Address should be able to add tokens");
-
-        })
-
-        it ("User should not be able to add duplicate tokens", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.addChannel(ThingToken.options.address,userAddress,recipientAddress,10).send({from:userAddress})
-                assert.fail("User should never be able to add duplicate tokens");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        })
-
-        it ("Recipient Address should not be able to add duplicate tokens", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.addChannel(ThingToken.options.address,userAddress,recipientAddress,10).send({from:recipientAddress})
-                assert.fail("Recipient Address should never be able to add duplicate tokens");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        })
-
-        it("User cannot close an uninitialized channel", async() =>
-        {
-            const transfer = 50;
-            await ThingToken.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ThingToken.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-
-            amount = 0;
-            const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ThingToken.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:userAddress});
-                assert.fail("User cannot close with amount greater than escrow");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient Address cannot close an uninitialized channel", async() =>
-        {
-
-            amount = 0;
-            const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ThingToken.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:recipientAddress});
-                assert.fail("User cannot close with amount greater than escrow");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("User cannot settle an uninitialized channel", async() =>
-        {
-
-            amount = 0;
-            const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.settle(ThingToken.options.address).send({from:userAddress});
-                assert.fail("User cannot settle an uninitialized channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient Address cannot settle an uninitialized channel", async() =>
-        {
-
-            amount = 0;
-            const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.settle(ThingToken.options.address).send({from:recipientAddress});
-                assert.fail("Recipient Address cannot settle an uninitialized channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
+        try {
+            await MultiChannel.methods.close(ThingToken.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: recipientAddress
+            });
+            assert.fail("User cannot close with amount greater than escrow");
+        } catch (error) {
+            assertRevert(error);
+        }
     });
+
+    it("User cannot settle an uninitialized channel", async () => {
+
+        amount = 0;
+        const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.settle(ThingToken.options.address).send({
+                from: userAddress
+            });
+            assert.fail("User cannot settle an uninitialized channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Recipient Address cannot settle an uninitialized channel", async () => {
+
+        amount = 0;
+        const cryptoParams = closingHelper.getClosingParameters(ThingToken.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.settle(ThingToken.options.address).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address cannot settle an uninitialized channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+});

--- a/test/AdditionalTokens.js
+++ b/test/AdditionalTokens.js
@@ -53,7 +53,7 @@ config({
                 0,
                 0
             ],
-            "fromIndex": 1
+            "from": recipientAddress
         },
         "MultiChannel": {
             args: [

--- a/test/AdditionalTokens.js
+++ b/test/AdditionalTokens.js
@@ -9,69 +9,62 @@ const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
 let userAddress = allAccounts[0];
 let recipientAddress = allAccounts[1];
-let signerAddress = allAccounts[2];
+let signerAddress = allAccounts[2]; 
 let nonParticipantAddress = allAccounts[3];
+const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
+var nonce = 1;
 
-config({
-    "deployment": {
-        "accounts": [{
-            "mnemonic": testConstant.MNEMONIC,
-            "numAddresses": testConstant.NUM_ADDRESS,
-            "addressIndex": testConstant.INDEX,
-            "hdpath": testConstant.PATH
-        }]
-    },
-    contracts: {
-        "Token": {
-
-        },
-        "StandardToken": {
-
-        },
-        "WETHToken": {
-            args: [initialCreation, "WETH", 18, "STK"],
-            "instanceOf": "ERC20Token",
-            "from": nonParticipantAddress
-        },
-        "ThingToken": {
-            args: [initialCreation, "Thing", 18, "THG"],
-            "instanceOf": "ERC20Token",
-            "from": nonParticipantAddress
-        },
-        "ERC20Token": {
-            args: [initialCreation, 'STK', 18, 'STK'],
-            "from": nonParticipantAddress
-        },
-        MultiLibrary: {
-            args: [
-                '$ERC20Token',
-                '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
-                signerAddress,
-                recipientAddress,
-                timeout,
-                1,
-                0,
-                0
-            ],
-            "from": recipientAddress
-        },
-        "MultiChannel": {
-            args: [
-                userAddress,
-                signerAddress,
-                '$ERC20Token',
-                timeout
-            ],
-            "from": recipientAddress
-        }
-    }
-});
-
-contract("Testing Users Adding Other Tokens", function () {
-    this.timeout(0);
-    const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
-    var nonce = 1;
-
+contract("Additional Token Tests", function () {
+    beforeEach((done) => {
+        config({
+            "deployment": {
+                "accounts": [{
+                    "mnemonic": testConstant.MNEMONIC,
+                    "numAddresses": testConstant.NUM_ADDRESS,
+                    "addressIndex": testConstant.INDEX,
+                    "hdpath": testConstant.PATH
+                }]
+            },
+            contracts: {
+                "WETHToken": {
+                    args: [initialCreation, "WETH", 18, "STK"],
+                    "instanceOf": "ERC20Token",
+                    "from": nonParticipantAddress
+                },
+                "ThingToken": {
+                    args: [initialCreation, "Thing", 18, "THG"],
+                    "instanceOf": "ERC20Token",
+                    "from": nonParticipantAddress
+                },
+                "ERC20Token": {
+                    args: [initialCreation, 'STK', 18, 'STK'],
+                    "from": nonParticipantAddress
+                },
+                MultiLibrary: {
+                    args: [
+                        '$ERC20Token',
+                        '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
+                        signerAddress,
+                        recipientAddress,
+                        timeout,
+                        1,
+                        0,
+                        0
+                    ],
+                    "from": recipientAddress
+                },
+                "MultiChannel": {
+                    args: [
+                        userAddress,
+                        signerAddress,
+                        '$ERC20Token',
+                        timeout
+                    ],
+                    "from": recipientAddress
+                }
+            }
+        }, done);
+    });
     it("Non channel participant should not be able to add tokens", async () => {
         try {
             await MultiChannel.methods.addChannel(WETHToken.options.address, userAddress, recipientAddress, 10).send({
@@ -103,6 +96,9 @@ contract("Testing Users Adding Other Tokens", function () {
     })
 
     it("User should not be able to add duplicate tokens", async () => {
+        await MultiChannel.methods.addChannel(ThingToken.options.address, userAddress, recipientAddress, 10).send({
+            from: recipientAddress
+        });        
         try {
             await MultiChannel.methods.addChannel(ThingToken.options.address, userAddress, recipientAddress, 10).send({
                 from: userAddress
@@ -114,6 +110,9 @@ contract("Testing Users Adding Other Tokens", function () {
     })
 
     it("Recipient Address should not be able to add duplicate tokens", async () => {
+        await MultiChannel.methods.addChannel(ThingToken.options.address, userAddress, recipientAddress, 10).send({
+            from: recipientAddress
+        });         
         try {
             await MultiChannel.methods.addChannel(ThingToken.options.address, userAddress, recipientAddress, 10).send({
                 from: recipientAddress

--- a/test/ERC20Token.js
+++ b/test/ERC20Token.js
@@ -7,7 +7,6 @@ let nonParticipantAddress = allAccounts[3];
 let userAddress = allAccounts[0];
 let recipientAddress = allAccounts[1];
 let signerAddress = allAccounts[2];
-let nonParticipantAddress = allAccounts[3];
 config({
     "deployment": {
         "accounts": [{

--- a/test/ERC20Token.js
+++ b/test/ERC20Token.js
@@ -4,7 +4,10 @@ const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
 let nonParticipantAddress = allAccounts[3];
-
+let userAddress = allAccounts[0];
+let recipientAddress = allAccounts[1];
+let signerAddress = allAccounts[2];
+let nonParticipantAddress = allAccounts[3];
 config({
     "deployment": {
         "accounts": [{
@@ -24,23 +27,23 @@ config({
         "WETHToken": {
             args: [initialCreation, "WETH", 18, "STK"],
             "instanceOf": "ERC20Token",
-            "from": allAccounts[3]
+            "from": nonParticipantAddress
         },
         "ThingToken": {
             args: [initialCreation, "Thing", 18, "THG"],
             "instanceOf": "ERC20Token",
-            "from": allAccounts[3]
+            "from": nonParticipantAddress
         },
         "ERC20Token": {
             args: [initialCreation, 'STK', 18, 'STK'],
-            "from": allAccounts[3]
+            "from": nonParticipantAddress
         },
         MultiLibrary: {
             args: [
                 '$ERC20Token',
                 '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
-                allAccounts[2],
-                allAccounts[1],
+                signerAddress,
+                recipientAddress,
                 timeout,
                 1,
                 0,
@@ -50,12 +53,12 @@ config({
         },
         "MultiChannel": {
             args: [
-                allAccounts[0],
-                allAccounts[2],
+                userAddress,
+                signerAddress,
                 '$ERC20Token',
                 timeout
             ],
-            "from": allAccounts[1]
+            "from": recipientAddress
         }
     }
 });

--- a/test/ERC20Token.js
+++ b/test/ERC20Token.js
@@ -3,14 +3,14 @@ const testConstant = require('./helpers/testConstant');
 const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
-let userAddress = allAccounts[0];
-let recipientAddress = allAccounts[1];
-let signerAddress = allAccounts[2];
-let nonParticipantAddress = allAccounts[3];
+const userAddress = allAccounts[0];
+const recipientAddress = allAccounts[1];
+const signerAddress = allAccounts[2];
+const nonParticipantAddress = allAccounts[3];
 const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
 const userPk = Buffer.from(testConstant.USER_PK, 'hex');
 const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-var nonce = 1;
+let nonce = 1;
 
 contract("ERC20 Token Tests", function () {
     beforeEach((done) => {
@@ -41,7 +41,6 @@ contract("ERC20 Token Tests", function () {
                 MultiLibrary: {
                     args: [
                         '$ERC20Token',
-                        '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
                         signerAddress,
                         recipientAddress,
                         timeout,

--- a/test/ERC20Token.js
+++ b/test/ERC20Token.js
@@ -3,67 +3,68 @@ const testConstant = require('./helpers/testConstant');
 const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
-let nonParticipantAddress = allAccounts[3];
 let userAddress = allAccounts[0];
 let recipientAddress = allAccounts[1];
 let signerAddress = allAccounts[2];
-config({
-    "deployment": {
-        "accounts": [{
-            "mnemonic": testConstant.MNEMONIC,
-            "numAddresses": testConstant.NUM_ADDRESS,
-            "addressIndex": testConstant.INDEX,
-            "hdpath": testConstant.PATH
-        }]
-    },
-    contracts: {
-        "Token": {
+let nonParticipantAddress = allAccounts[3];
+const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
+const userPk = Buffer.from(testConstant.USER_PK, 'hex');
+const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
+var nonce = 1;
 
-        },
-        "StandardToken": {
+contract("ERC20 Token Tests", function () {
+    beforeEach((done) => {
+        config({
+            "deployment": {
+                "accounts": [{
+                    "mnemonic": testConstant.MNEMONIC,
+                    "numAddresses": testConstant.NUM_ADDRESS,
+                    "addressIndex": testConstant.INDEX,
+                    "hdpath": testConstant.PATH
+                }]
+            },
+            contracts: {
+                "WETHToken": {
+                    args: [initialCreation, "WETH", 18, "STK"],
+                    "instanceOf": "ERC20Token",
+                    "from": nonParticipantAddress
+                },
+                "ThingToken": {
+                    args: [initialCreation, "Thing", 18, "THG"],
+                    "instanceOf": "ERC20Token",
+                    "from": nonParticipantAddress
+                },
+                "ERC20Token": {
+                    args: [initialCreation, 'STK', 18, 'STK'],
+                    "from": nonParticipantAddress
+                },
+                MultiLibrary: {
+                    args: [
+                        '$ERC20Token',
+                        '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
+                        signerAddress,
+                        recipientAddress,
+                        timeout,
+                        1,
+                        0,
+                        0
+                    ],
+                    "from": recipientAddress
+                },
+                "MultiChannel": {
+                    args: [
+                        userAddress,
+                        signerAddress,
+                        '$ERC20Token',
+                        timeout
+                    ],
+                    "from": recipientAddress
+                }
+            }
+        }, done);
+    });
 
-        },
-        "WETHToken": {
-            args: [initialCreation, "WETH", 18, "STK"],
-            "instanceOf": "ERC20Token",
-            "from": nonParticipantAddress
-        },
-        "ThingToken": {
-            args: [initialCreation, "Thing", 18, "THG"],
-            "instanceOf": "ERC20Token",
-            "from": nonParticipantAddress
-        },
-        "ERC20Token": {
-            args: [initialCreation, 'STK', 18, 'STK'],
-            "from": nonParticipantAddress
-        },
-        MultiLibrary: {
-            args: [
-                '$ERC20Token',
-                '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
-                signerAddress,
-                recipientAddress,
-                timeout,
-                1,
-                0,
-                0
-            ],
-            "from": recipientAddress
-        },
-        "MultiChannel": {
-            args: [
-                userAddress,
-                signerAddress,
-                '$ERC20Token',
-                timeout
-            ],
-            "from": recipientAddress
-        }
-    }
-});
 
-contract("Testing ERC20 Tokens", function () {
-    this.timeout(0);
 
     it("STK Token is deployed ", function () {
         let ERC20TokenAddress = ERC20Token.options.address;

--- a/test/ERC20Token.js
+++ b/test/ERC20Token.js
@@ -48,7 +48,7 @@ config({
                 0,
                 0
             ],
-            "fromIndex": 1
+            "from": recipientAddress
         },
         "MultiChannel": {
             args: [

--- a/test/ERC20Token.js
+++ b/test/ERC20Token.js
@@ -1,103 +1,86 @@
-
-const MultiChannel = require('Embark/contracts/MultiChannel');
 const ERC20Token = require('Embark/contracts/ERC20Token');
-const MultiLibrary = require('Embark/contracts/MultiLibrary');
-const indexes = require('./helpers/ChannelDataIndexes.js')
-const StandardToken = require('Embark/contracts/StandardToken.sol');
-const Token = require('Embark/contracts/Token.sol');
-const closingHelper = require('./helpers/channelClosingHelper');
-const assertRevert = require('./helpers/assertRevert');
 const testConstant = require('./helpers/testConstant');
-const allAccounts = testConstant.ACCOUNTS; 
+const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
+let nonParticipantAddress = allAccounts[3];
 
 config({
     "deployment": {
-        "accounts": [
-            {
-                "mnemonic":testConstant.MNEMONIC,
-                "numAddresses":testConstant.NUM_ADDRESS,
-                "addressIndex": testConstant.INDEX,
-                "hdpath":testConstant.PATH
-            }
-        ]},
-        contracts: {
-            "Token": {
+        "accounts": [{
+            "mnemonic": testConstant.MNEMONIC,
+            "numAddresses": testConstant.NUM_ADDRESS,
+            "addressIndex": testConstant.INDEX,
+            "hdpath": testConstant.PATH
+        }]
+    },
+    contracts: {
+        "Token": {
 
-            },
-            "StandardToken": {
+        },
+        "StandardToken": {
 
-            },
-            "WETHToken": {
-                args:[initialCreation, "WETH", 18, "STK"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ThingToken": {
-                args:[initialCreation, "Thing", 18, "THG"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ERC20Token": {
-                args: [initialCreation,'STK', 18, 'STK'],
-                "from": allAccounts[3]
-            },
-            MultiLibrary: {
-                args: [
-                    '$ERC20Token',
-                    '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
-                    allAccounts[2],
-                    allAccounts[1],
-                    timeout,
-                    1,
-                    0,
-                    0
-                ],
-                "fromIndex":1
-            },
-            "MultiChannel": {
-                args: [
-                    allAccounts[0],
-                    allAccounts[2],
-                    '$ERC20Token',
-                    timeout
-                ],
-                "from": allAccounts[1]
-            }
+        },
+        "WETHToken": {
+            args: [initialCreation, "WETH", 18, "STK"],
+            "instanceOf": "ERC20Token",
+            "from": allAccounts[3]
+        },
+        "ThingToken": {
+            args: [initialCreation, "Thing", 18, "THG"],
+            "instanceOf": "ERC20Token",
+            "from": allAccounts[3]
+        },
+        "ERC20Token": {
+            args: [initialCreation, 'STK', 18, 'STK'],
+            "from": allAccounts[3]
+        },
+        MultiLibrary: {
+            args: [
+                '$ERC20Token',
+                '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
+                allAccounts[2],
+                allAccounts[1],
+                timeout,
+                1,
+                0,
+                0
+            ],
+            "fromIndex": 1
+        },
+        "MultiChannel": {
+            args: [
+                allAccounts[0],
+                allAccounts[2],
+                '$ERC20Token',
+                timeout
+            ],
+            "from": allAccounts[1]
         }
+    }
+});
+
+contract("Testing ERC20 Tokens", function () {
+    this.timeout(0);
+
+    it("STK Token is deployed ", function () {
+        let ERC20TokenAddress = ERC20Token.options.address;
+        assert.ok(ERC20TokenAddress.length > 0);
     });
 
-    contract("Testing ERC20 Tokens", function () {
-        this.timeout(0);
-        let userAddress = allAccounts[0]; 
-        let recipientAddress= allAccounts[1]; 
-        let signerAddress = allAccounts[2]; 
-        const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
-        const userPk = Buffer.from(testConstant.USER_PK,'hex');
-        const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-        const recipientAddressPk = Buffer.from(testConstant.RECIPIENT_PK,'hex');
-        var nonce = 1;
-        
-        it("STK Token is deployed ", function()
-        {
-            let ERC20TokenAddress = ERC20Token.options.address;
-            assert.ok(ERC20TokenAddress.length > 0);
-        });
+    it("STK Token should have 1 billion tokens in initialized account after declaration", async () => {
+        const balance = await ERC20Token.methods.balanceOf(nonParticipantAddress).call();
+        assert.equal(balance.valueOf(), 1000000000, '1 billion was not in the first account');
+    });
 
-        it("STK Token should have 1 billion tokens in initialized account after declaration", async()=> {
-            const balance = await ERC20Token.methods.balanceOf(allAccounts[3]).call(); 
-            assert.equal(balance.valueOf(), 1000000000, '1 billion was not in the first account');
-        });
-        
-        it('STK Token should have symbol as Multi',async()=> {
-            const symbol = await ERC20Token.symbol.call();
-            assert.equal(symbol,'STK','Symbol is not STK');
-        });  
-        
-        it('STK Token should have 18 decimal points', async() => { 
-            const decimal = await ERC20Token.decimals.call(); 
-            assert.equal(decimal, 18, "Decimal points is not 18"); 
-        })
-    
+    it('STK Token should have symbol as STK', async () => {
+        const symbol = await ERC20Token.symbol.call();
+        assert.equal(symbol, 'STK', 'Symbol is not STK');
+    });
+
+    it('STK Token should have 18 decimal points', async () => {
+        const decimal = await ERC20Token.decimals.call();
+        assert.equal(decimal, 18, "Decimal points is not 18");
+    })
+
 });

--- a/test/IllegalStateTransition.js
+++ b/test/IllegalStateTransition.js
@@ -7,14 +7,14 @@ const testConstant = require('./helpers/testConstant');
 const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
-let userAddress = allAccounts[0];
-let recipientAddress = allAccounts[1];
-let signerAddress = allAccounts[2]; 
-let nonParticipantAddress = allAccounts[3];
+const userAddress = allAccounts[0];
+const recipientAddress = allAccounts[1];
+const signerAddress = allAccounts[2]; 
+const nonParticipantAddress = allAccounts[3];
 const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
 const userPk = Buffer.from(testConstant.USER_PK, 'hex');
 const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-var nonce = 1;
+let nonce = 1;
 
 contract("Illegal State Transition", function () {
     beforeEach((done) => {
@@ -45,7 +45,6 @@ contract("Illegal State Transition", function () {
                 MultiLibrary: {
                     args: [
                         '$ERC20Token',
-                        '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
                         signerAddress,
                         recipientAddress,
                         timeout,
@@ -110,7 +109,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 1;
+        let amount = 1;
         const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         try {
             await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
@@ -146,7 +145,7 @@ contract("Illegal State Transition", function () {
 
     it("User cannot close channel with amount greater than deposited", async () => {
         nonce++;
-        var amount = 150;
+        let amount = 150;
 
         const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         try {
@@ -232,7 +231,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -266,7 +265,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -300,7 +299,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -333,7 +332,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -365,7 +364,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -396,7 +395,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -426,7 +425,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -461,7 +460,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -497,7 +496,7 @@ contract("Illegal State Transition", function () {
         });
 
         nonce++; 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -533,7 +532,7 @@ contract("Illegal State Transition", function () {
         });
 
         nonce++; 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -568,7 +567,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -600,7 +599,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -632,7 +631,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -641,7 +640,7 @@ contract("Illegal State Transition", function () {
 
         amount = 1;
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,
@@ -677,7 +676,7 @@ contract("Illegal State Transition", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
@@ -686,7 +685,7 @@ contract("Illegal State Transition", function () {
 
         amount = 1;
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,

--- a/test/IllegalStateTransition.js
+++ b/test/IllegalStateTransition.js
@@ -1,446 +1,410 @@
 const MultiChannel = require('Embark/contracts/MultiChannel');
 const ERC20Token = require('Embark/contracts/ERC20Token');
-const MultiLibrary = require('Embark/contracts/MultiLibrary');
-const indexes = require('./helpers/ChannelDataIndexes.js')
-const StandardToken = require('Embark/contracts/StandardToken.sol');
-const Token = require('Embark/contracts/Token.sol');
 const closingHelper = require('./helpers/channelClosingHelper');
 const assertRevert = require('./helpers/assertRevert');
 const testConstant = require('./helpers/testConstant');
-const allAccounts = testConstant.ACCOUNTS; 
+const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
+let userAddress = allAccounts[0];
+let recipientAddress = allAccounts[1];
+let signerAddress = allAccounts[2];
+let nonParticipantAddress = allAccounts[3];
+const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
+const userPk = Buffer.from(testConstant.USER_PK, 'hex');
+const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
+var nonce = 1;
 
 config({
     "deployment": {
-        "accounts": [
-            {
-                "mnemonic":testConstant.MNEMONIC,
-                "numAddresses":testConstant.NUM_ADDRESS,
-                "addressIndex": testConstant.INDEX,
-                "hdpath":testConstant.PATH
-            }
-        ]},
-        contracts: {
-            "Token": {
+        "accounts": [{
+            "mnemonic": testConstant.MNEMONIC,
+            "numAddresses": testConstant.NUM_ADDRESS,
+            "addressIndex": testConstant.INDEX,
+            "hdpath": testConstant.PATH
+        }]
+    },
+    contracts: {
+        "Token": {
 
-            },
-            "StandardToken": {
+        },
+        "StandardToken": {
 
-            },
-            "WETHToken": {
-                args:[initialCreation, "WETH", 18, "STK"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ThingToken": {
-                args:[initialCreation, "Thing", 18, "THG"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ERC20Token": {
-                args: [initialCreation,'STK', 18, 'STK'],
-                "from": allAccounts[3]
-            },
-            MultiLibrary: {
-                args: [
-                    '$ERC20Token',
-                    '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
-                    allAccounts[2],
-                    allAccounts[1],
-                    timeout,
-                    1,
-                    0,
-                    0
-                ],
-                "fromIndex":1
-            },
-            "MultiChannel": {
-                args: [
-                    allAccounts[0],
-                    allAccounts[2],
-                    '$ERC20Token',
-                    timeout
-                ],
-                "from": allAccounts[1]
-            }
+        },
+        "WETHToken": {
+            args: [initialCreation, "WETH", 18, "STK"],
+            "instanceOf": "ERC20Token",
+            "from": nonParticipantAddress
+        },
+        "ThingToken": {
+            args: [initialCreation, "Thing", 18, "THG"],
+            "instanceOf": "ERC20Token",
+            "from": nonParticipantAddress
+        },
+        "ERC20Token": {
+            args: [initialCreation, 'STK', 18, 'STK'],
+            "from": nonParticipantAddress
+        },
+        MultiLibrary: {
+            args: [
+                '$ERC20Token',
+                '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
+                signerAddress,
+                signerAddress,
+                timeout,
+                1,
+                0,
+                0
+            ],
+            "fromIndex": 1
+        },
+        "MultiChannel": {
+            args: [
+                userAddress,
+                signerAddress,
+                '$ERC20Token',
+                timeout
+            ],
+            "from": signerAddress
+        }
+    }
+});
+
+contract("Testing Illegal State Transitions", function () {
+    this.timeout(0);
+
+
+    it("User should not be able to update an open channel", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+
+        amount = 1;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: userAddress
+            });
+            assert.fail("User should never be able to contest an open channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    })
+
+    it("Recipient Address should not be able to update an open channel", async () => {
+        amount = 1;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address should never be able to contest an open channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    })
+
+    it("User should not be able to settle an open channel", async () => {
+        try {
+            await MultiChannel.methods.settle(ERC20Token.options.address).send({
+                from: userAddress
+            });
+            assert.fail("User should never be able to settle an open channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    })
+
+    it("Recipient Address should not be able to update an open channel", async () => {
+        try {
+            await MultiChannel.methods.settle(ERC20Token.options.address).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address should never be able to settle an open channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    })
+
+    it("User cannot close channel with amount greater than deposited", async () => {
+        const amount = 150;
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: userAddress
+            });
+            assert.fail("User cannot close with amount greater than escrow");
+        } catch (error) {
+            assertRevert(error);
         }
     });
 
-    contract("Testing Illegal State Transitions", function () {
-        this.timeout(0);
-        let userAddress = allAccounts[0]; 
-        let recipientAddress= allAccounts[1]; 
-        let signerAddress = allAccounts[2]; 
-        const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
-        const userPk = Buffer.from(testConstant.USER_PK,'hex');
-        const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-        var nonce = 1;
+    it("User cannot close channel with signer address signed transaction", async () => {
+        nonce++;
+        const amount = 2;
 
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
 
-        it ("User should not be able to update an open channel", async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-
-            amount = 1;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:userAddress});
-                assert.fail("User should never be able to contest an open channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        })
-
-        it ("Recipient Address should not be able to update an open channel", async() =>
-        {
-            amount = 1;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:recipientAddress});
-                assert.fail("Recipient Address should never be able to contest an open channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        })
-
-        it ("User should not be able to settle an open channel", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.settle(ERC20Token.options.address).send({from:userAddress});
-                assert.fail("User should never be able to settle an open channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        })
-
-        it ("Recipient Address should not be able to update an open channel", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.settle(ERC20Token.options.address).send({from:recipientAddress});
-                assert.fail("Recipient Address should never be able to settle an open channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        })        
-
-        it("User cannot close channel with amount greater than deposited", async() =>
-        {
-            const amount = 150;
-
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:userAddress});
-                assert.fail("User cannot close with amount greater than escrow");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("User cannot close channel with signer address signed transaction", async() =>
-        {
-            nonce++; 
-            const amount = 2;
-
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:userAddress});
-                assert.fail("User cannot close with amount greater than escrow");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient Address cannot close channel with amount greater than deposited", async() =>
-        {
-            const amount = 150;
-
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:recipientAddress});
-                assert.fail("Recipient Address cannot close with amount greater than escrow");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("User cannot close channel with self-signed signature", async() =>
-        {
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,userPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:userAddress});
-                assert.fail("User cannot sign with self-signed signature");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient Address cannot close channel with self-signed signature", async() =>
-        {
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,recipientPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:recipientAddress});
-                assert.fail("Recipient Address cannot sign with self-signed signature");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("User cannot use the same nonce for contesting channel", async() =>
-        {
-            nonce++;
-            const amount = 2;
-
-            const properClose = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce,amount,properClose.v,properClose.r,properClose.s,true).send({from:allAccounts[1]});
-
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:userAddress});
-                assert.fail("User should not use the same nonce for contest");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient Address cannot use the same nonce for contesting channel", async() =>
-        {
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:recipientAddress});
-                assert.fail("Recipient Address should not use the same nonce for contest");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("User cannot close a closed channel", async() =>
-        {
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:userAddress});
-                assert.fail("User cannot close a closed channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient Address cannot close a closed channel", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.closeWithoutSignature().send({from:recipientAddress}); 
-                assert.fail("Recipient Address should not be able to close without sig on an already closed channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("User should not be able to close without signature on an already closed channel", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.closeWithoutSignature().send({from:userAddress}); 
-                assert.fail("User should not be able to close without sig on an already closed channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient Address should not be able to close without signature on an already closed channel", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.closeWithoutSignature().send({from:recipientAddress}); 
-                assert.fail("Recipient Address should not be able to close without sig on an already closed channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-        it("User should not contest an amount greater than deposited", async() =>
-        {
-            amount = 10000;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:userAddress});
-                assert.fail("User should not be able to update a closed channel with an amount greater than what's placed in escrow");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient should not be able to contest an amount greater than deposited", async() =>
-        {
-            amount = 10000;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:recipientAddress});
-                assert.fail("Recipient Address should not be able to update a closed channel with an amount greater than what's placed in escrow");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient should not be able to contest with self-signed signature", async() =>
-        {
-            amount = 3; 
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,recipientPk);
-
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:recipientAddress});
-                assert.fail("Recipient Address should not be able to contest with a self-signed signature");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });        
-
-        it("User should not be able to contest with self-signed signature", async() =>
-        {
-            amount = 3; 
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,userPk);
-
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:userPk});
-                assert.fail("Recipient Address should not be able to contest with a self-signed signature");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });        
-
-        it("User should not be able to settle before time period is over", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.settle(ERC20Token.options.address).send({from:userAddress});
-                assert.fail("User should never be able to settle before contest period is over")
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient Address should not be able to settle before time period is over", async() =>
-        {
-            try
-            {
-                await MultiChannel.methods.settle(ERC20Token.options.address).send({from:recipientAddress});
-                assert.fail("Recipient Address should never be able to settle before contest period is over")
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Recipient Address should not be able to contest after contest period is over", async() =>
-        {
-            const amount = 1; 
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }      
-
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce,amount, cryptoParams.v,cryptoParams.r,cryptoParams.s).send({from:recipientAddress});
-                assert.fail("Recipient Address should not be able to update a channel after contest period is over");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });        
-
-        it("User should not be able to contest after contest period is over", async() =>
-        {
-            const amount = 1; 
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }      
-
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,recipientPk);
-
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:userAddress});
-                assert.fail("User should not be able to update a channel after contest period is over");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });          
-
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: userAddress
+            });
+            assert.fail("User cannot close with amount greater than escrow");
+        } catch (error) {
+            assertRevert(error);
+        }
     });
+
+    it("Recipient Address cannot close channel with amount greater than deposited", async () => {
+        const amount = 150;
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address cannot close with amount greater than escrow");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("User cannot close channel with self-signed signature", async () => {
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, userPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: userAddress
+            });
+            assert.fail("User cannot sign with self-signed signature");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Recipient Address cannot close channel with self-signed signature", async () => {
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, recipientPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address cannot sign with self-signed signature");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("User cannot use the same nonce for contesting channel", async () => {
+        nonce++;
+        const amount = 2;
+
+        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+            from: recipientAddress
+        });
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: userAddress
+            });
+            assert.fail("User should not use the same nonce for contest");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Recipient Address cannot use the same nonce for contesting channel", async () => {
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address should not use the same nonce for contest");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("User cannot close a closed channel", async () => {
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: userAddress
+            });
+            assert.fail("User cannot close a closed channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Recipient Address cannot close a closed channel", async () => {
+        try {
+            await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address should not be able to close without sig on an already closed channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("User should not be able to close without signature on an already closed channel", async () => {
+        try {
+            await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({
+                from: userAddress
+            });
+            assert.fail("User should not be able to close without sig on an already closed channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Recipient Address should not be able to close without signature on an already closed channel", async () => {
+        try {
+            await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address should not be able to close without sig on an already closed channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+    it("User should not contest an amount greater than deposited", async () => {
+        amount = 10000;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: userAddress
+            });
+            assert.fail("User should not be able to update a closed channel with an amount greater than what's placed in escrow");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Recipient should not be able to contest an amount greater than deposited", async () => {
+        amount = 10000;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address should not be able to update a closed channel with an amount greater than what's placed in escrow");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Recipient should not be able to contest with self-signed signature", async () => {
+        amount = 3;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, recipientPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address should not be able to contest with a self-signed signature");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("User should not be able to contest with self-signed signature", async () => {
+        amount = 3;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, userPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: userPk
+            });
+            assert.fail("Recipient Address should not be able to contest with a self-signed signature");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("User should not be able to settle before time period is over", async () => {
+        try {
+            await MultiChannel.methods.settle(ERC20Token.options.address).send({
+                from: userAddress
+            });
+            assert.fail("User should never be able to settle before contest period is over")
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Recipient Address should not be able to settle before time period is over", async () => {
+        try {
+            await MultiChannel.methods.settle(ERC20Token.options.address).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address should never be able to settle before contest period is over")
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Recipient Address should not be able to contest after contest period is over", async () => {
+        const amount = 1;
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonParticipantAddress,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: recipientAddress
+            });
+            assert.fail("Recipient Address should not be able to update a channel after contest period is over");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("User should not be able to contest after contest period is over", async () => {
+        const amount = 1;
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonParticipantAddress,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, recipientPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: userAddress
+            });
+            assert.fail("User should not be able to update a channel after contest period is over");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+});

--- a/test/NonChannelParticipant.js
+++ b/test/NonChannelParticipant.js
@@ -1,374 +1,347 @@
 const MultiChannel = require('Embark/contracts/MultiChannel');
 const ERC20Token = require('Embark/contracts/ERC20Token');
 const MultiLibrary = require('Embark/contracts/MultiLibrary');
-const indexes = require('./helpers/ChannelDataIndexes.js')
-const StandardToken = require('Embark/contracts/StandardToken.sol');
-const Token = require('Embark/contracts/Token.sol');
 const closingHelper = require('./helpers/channelClosingHelper');
 const assertRevert = require('./helpers/assertRevert');
 const testConstant = require('./helpers/testConstant');
-const allAccounts = testConstant.ACCOUNTS; 
+const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
+let userAddress = allAccounts[0];
+let recipientAddress = allAccounts[1];
+let signerAddress = allAccounts[2];
+let nonParticipantAddress = allAccounts[3];
 
 config({
     "deployment": {
-        "accounts": [
-            {
-                "mnemonic":testConstant.MNEMONIC,
-                "numAddresses":testConstant.NUM_ADDRESS,
-                "addressIndex": testConstant.INDEX,
-                "hdpath":testConstant.PATH
-            }
-        ]},
-        contracts: {
-            "Token": {
+        "accounts": [{
+            "mnemonic": testConstant.MNEMONIC,
+            "numAddresses": testConstant.NUM_ADDRESS,
+            "addressIndex": testConstant.INDEX,
+            "hdpath": testConstant.PATH
+        }]
+    },
+    contracts: {
+        "WETHToken": {
+            args: [initialCreation, "WETH", 18, "STK"],
+            "instanceOf": "ERC20Token",
+            "from": nonParticipantAddress
+        },
+        "ThingToken": {
+            args: [initialCreation, "Thing", 18, "THG"],
+            "instanceOf": "ERC20Token",
+            "from": nonParticipantAddress
+        },
+        "ERC20Token": {
+            args: [initialCreation, 'STK', 18, 'STK'],
+            "from": nonParticipantAddress
+        },
+        MultiLibrary: {
+            args: [
+                '$ERC20Token',
+                '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
+                signerAddress,
+                recipientAddress,
+                timeout,
+                1,
+                0,
+                0
+            ],
+            "fromIndex": 1
+        },
+        "MultiChannel": {
+            args: [
+                userAddress,
+                signerAddress,
+                '$ERC20Token',
+                timeout
+            ],
+            "from": recipientAddress
+        }
+    }
+});
 
-            },
-            "StandardToken": {
+contract("Testing Non Channel Participants", function () {
+    this.timeout(0);
+    const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
+    const nonParticipantPK = Buffer.from(testConstant.NON_PARTICIPANT, 'hex');
+    var nonce = 1;
 
-            },
-            "WETHToken": {
-                args:[initialCreation, "WETH", 18, "STK"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ThingToken": {
-                args:[initialCreation, "Thing", 18, "THG"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ERC20Token": {
-                args: [initialCreation,'STK', 18, 'STK'],
-                "from": allAccounts[3]
-            },
-            MultiLibrary: {
-                args: [
-                    '$ERC20Token',
-                    '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
-                    allAccounts[2],
-                    allAccounts[1],
-                    timeout,
-                    1,
-                    0,
-                    0
-                ],
-                "fromIndex":1
-            },
-            "MultiChannel": {
-                args: [
-                    allAccounts[0],
-                    allAccounts[2],
-                    '$ERC20Token',
-                    timeout
-                ],
-                "from": allAccounts[1]
-            }
+
+    it("Cannot close a channel with valid signature", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+
+        const amount = 5;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Non channel participant should not be able to close an open channel with a valid signature");
+        } catch (error) {
+            assertRevert(error);
+            assert.ok(true);
+        }
+    })
+
+    it("Cannot close open channel without signature", async () => {
+        try {
+            await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Cannot close without signature");
+        } catch (error) {
+            assertRevert(error);
+            assert.ok(true);
+        }
+    })
+
+    it("Cannot close a channel with an invalid signature", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+
+        nonce++;
+        const amount = 5;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, nonParticipantPK);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Self signed signature should be invalid");
+        } catch (error) {
+            assertRevert(error);
+            assert.ok(true);
+        }
+    })
+
+    it("Cannot close a closed channel with valid signature", async () => {
+        nonce++;
+        const amount = 2;
+
+        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+            from: recipientAddress
+        });
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Proper signed signature should not be able to close an already closed channel");
+        } catch (error) {
+            assertRevert(error);
         }
     });
 
-    contract("Testing Non Channel Participants", function () {
-        this.timeout(0);
-        let userAddress = allAccounts[0]; 
-        let recipientAddress= allAccounts[1]; 
-        let signerAddress = allAccounts[2]; 
-        let nonParticipantAddress = allAccounts[3]; 
-        const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
-        const userPk = Buffer.from(testConstant.USER_PK,'hex');
-        const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-        const recipientAddressPk = Buffer.from(testConstant.RECIPIENT_PK,'hex');
-        const nonParticipantPK = Buffer.from(testConstant.NON_PARTICIPANT,'hex'); 
-        var nonce = 1;
+    it("Cannot close a closed channel without signature", async () => {
+        try {
+            await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Cannot close an already closed channel without signature");
+        } catch (error) {
+            assertRevert(error);
+            assert.ok(true);
+        }
+    })
 
-
-        it("Cannot close a channel with valid signature",async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-            
-            const amount = 5;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
-            
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:accounts[5]});
-                assert.fail("Non channel participant should not be able to close an open channel with a valid signature");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-                assert.ok(true);
-            }
-        })
-
-        it("Cannot close open channel without signature", async() => 
-        { 
-            try 
-            {
-                await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({from:nonParticipantAddress}); 
-                assert.fail("Cannot close without signature"); 
-            } 
-            catch (error) 
-            { 
-                assertRevert(error); 
-                assert.ok(true); 
-            }
-        })
-        
-        it("Cannot close a channel with an invalid signature",async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: nonParticipantAddress});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: nonParticipantAddress});
-            
-            nonce++;
-            const amount = 5;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, nonParticipantPK);
-            
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:nonParticipantAddress});
-                assert.fail("Self signed signature should be invalid");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-                assert.ok(true);
-            }
-        })
-
-        it("Cannot close a closed channel with valid signature", async() =>
-        {
-            nonce++;
-            const amount = 2;
-            
-            const properClose = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce,amount,properClose.v,properClose.r,properClose.s,true).send({from:allAccounts[1]});
-            
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-            
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:nonParticipantAddress});
-                assert.fail("Proper signed signature should not be able to close an already closed channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Cannot close a closed channel without signature", async() => 
-        { 
-            try 
-            {
-                await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({from:nonParticipantAddress}); 
-                assert.fail("Cannot close an already closed channel without signature"); 
-            } 
-            catch (error) 
-            { 
-                assertRevert(error); 
-                assert.ok(true); 
-            }
-        })        
-
-        it("Cannot close without signature on closed channel", async() => 
-        {
-            try 
-            {
-                await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({from:nonParticipantAddress}); 
-                assert.fail("Cannot close without signature"); 
-            } 
-            catch (error) 
-            { 
-                assertRevert(error); 
-                assert.ok(true); 
-            }
-        }); 
-
-        it("Cannot contest an open channel with a valid signature",async() =>
-        {
-            nonce++;
-            const amount = 2;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
-            
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:nonParticipantAddress});
-                assert.fail("Non channel participant should not be able to change the state of an open channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-                assert.ok(true);
-            }
-        })        
-
-        it("Cannot contest an open channel with an invalid signature",async() =>
-        {
-            nonce++;
-            const amount = 2;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, nonParticipantPK);
-            
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:nonParticipantAddress});
-                assert.fail("Non channel participant should not be able to change the state of an open channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-                assert.ok(true);
-            }
-        })         
-        
-        it("Cannot settle an open channel",async() =>
-        {
-            nonce++;
-            const amount = 2;
-            
-            try
-            {
-                await MultiChannel.methods.settle(ERC20Token.options.address).send({from:nonParticipantAddress});
-                assert.fail("Non channel participant should not be able to change the state of an open channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-                assert.ok(true);
-            }
-        })          
-        
-        it("Cannot close a closed channel with invalid signature", async() =>
-        {
-            nonce++;
-            const amount = 2;
-            
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-            
-            try
-            {
-                await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:nonParticipantAddress});
-                assert.fail("Improperly signed signature should not be able to close an already closed channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });
-
-        it("Cannot contest channel with valid signature", async() =>
-        {
-            nonce++;
-            const amount = 2;
-            
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-            
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:nonParticipantAddress});
-                assert.fail("Non channel participant should not be able to contest channel with valid signature");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });        
-        
-        it("Cannot contest channel with valid signature", async() =>
-        {
-            nonce++;
-            const amount = 2;
-            
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-            
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:nonParticipantAddress});
-                assert.fail("Should not be able to contest channel with invalid signature");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });        
-        
-        it("Cannot contest channel with invalid signature", async() =>
-        {
-            nonce++;
-            const amount = 2;
-            
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,nonParticipantPK);
-            
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:nonParticipantAddress});
-                assert.fail("Non channel participant should not be able to contest");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });     
-
-        it("Cannot contest channel with valid signature after timeout", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }              
-            nonce++;
-            const amount = 2;
-            
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-            
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:nonParticipantAddress});
-                assert.fail("Should not be able to contest channel with invalid signature");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });        
-        
-        it("Cannot contest channel with invalid signature past timeout period", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }              
-            nonce++;
-            const amount = 2;
-            
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,nonParticipantPK);
-            
-            try
-            {
-                await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,true).send({from:nonParticipantAddress});
-                assert.fail("Non channel participant should not be able to contest");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });     
-
-        it("Cannot settle a closed channel", async() =>
-        {   
-            try
-            {
-                await MultiChannel.methods.settle(ERC20Token.options.address).send({from:nonParticipantAddress });
-                assert.fail("Non channel participant cannot change state of channel");
-            }
-            catch (error)
-            {
-                assertRevert(error);
-            }
-        });     
-
+    it("Cannot close without signature on closed channel", async () => {
+        try {
+            await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Cannot close without signature");
+        } catch (error) {
+            assertRevert(error);
+            assert.ok(true);
+        }
     });
+
+    it("Cannot contest an open channel with a valid signature", async () => {
+        nonce++;
+        const amount = 2;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Non channel participant should not be able to change the state of an open channel");
+        } catch (error) {
+            assertRevert(error);
+            assert.ok(true);
+        }
+    })
+
+    it("Cannot contest an open channel with an invalid signature", async () => {
+        nonce++;
+        const amount = 2;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, nonParticipantPK);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Non channel participant should not be able to change the state of an open channel");
+        } catch (error) {
+            assertRevert(error);
+            assert.ok(true);
+        }
+    })
+
+    it("Cannot settle an open channel", async () => {
+        nonce++;
+        const amount = 2;
+
+        try {
+            await MultiChannel.methods.settle(ERC20Token.options.address).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Non channel participant should not be able to change the state of an open channel");
+        } catch (error) {
+            assertRevert(error);
+            assert.ok(true);
+        }
+    })
+
+    it("Cannot close a closed channel with invalid signature", async () => {
+        nonce++;
+        const amount = 2;
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, true).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Improperly signed signature should not be able to close an already closed channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Cannot contest channel with valid signature", async () => {
+        nonce++;
+        const amount = 2;
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Non channel participant should not be able to contest channel with valid signature");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Cannot contest channel with valid signature", async () => {
+        nonce++;
+        const amount = 2;
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Should not be able to contest channel with invalid signature");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Cannot contest channel with invalid signature", async () => {
+        nonce++;
+        const amount = 2;
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, nonParticipantPK);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Non channel participant should not be able to contest");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Cannot contest channel with valid signature after timeout", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonParticipantAddress,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+        nonce++;
+        const amount = 2;
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Should not be able to contest channel with invalid signature");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Cannot contest channel with invalid signature past timeout period", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonParticipantAddress,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+        nonce++;
+        const amount = 2;
+
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, nonParticipantPK);
+
+        try {
+            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Non channel participant should not be able to contest");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+    it("Cannot settle a closed channel", async () => {
+        try {
+            await MultiChannel.methods.settle(ERC20Token.options.address).send({
+                from: nonParticipantAddress
+            });
+            assert.fail("Non channel participant cannot change state of channel");
+        } catch (error) {
+            assertRevert(error);
+        }
+    });
+
+});

--- a/test/NonChannelParticipant.js
+++ b/test/NonChannelParticipant.js
@@ -47,7 +47,7 @@ config({
                 0,
                 0
             ],
-            "fromIndex": 1
+            "from": recipientAddress
         },
         "MultiChannel": {
             args: [

--- a/test/NonChannelParticipant.js
+++ b/test/NonChannelParticipant.js
@@ -7,15 +7,15 @@ const testConstant = require('./helpers/testConstant');
 const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
-let userAddress = allAccounts[0];
-let recipientAddress = allAccounts[1];
-let signerAddress = allAccounts[2];
-let nonParticipantAddress = allAccounts[3];
+const userAddress = allAccounts[0];
+const recipientAddress = allAccounts[1];
+const signerAddress = allAccounts[2];
+const nonParticipantAddress = allAccounts[3];
 const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
 const userPk = Buffer.from(testConstant.USER_PK, 'hex');
 const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
 const nonParticipantPK = Buffer.from(testConstant.NON_PARTICIPANT, 'hex'); 
-var nonce = 1;
+let nonce = 1;
 
 contract("Non Channel Participant Actions", function () {
     beforeEach((done) => {
@@ -46,7 +46,6 @@ contract("Non Channel Participant Actions", function () {
                 MultiLibrary: {
                     args: [
                         '$ERC20Token',
-                        '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
                         signerAddress,
                         recipientAddress,
                         timeout,
@@ -175,8 +174,8 @@ contract("Non Channel Participant Actions", function () {
         nonce++;
         const amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
@@ -219,10 +218,10 @@ contract("Non Channel Participant Actions", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
@@ -299,10 +298,10 @@ contract("Non Channel Participant Actions", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
@@ -336,10 +335,10 @@ contract("Non Channel Participant Actions", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
@@ -373,10 +372,10 @@ contract("Non Channel Participant Actions", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
@@ -410,10 +409,10 @@ contract("Non Channel Participant Actions", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
@@ -447,16 +446,16 @@ contract("Non Channel Participant Actions", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
     
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,
@@ -494,16 +493,16 @@ contract("Non Channel Participant Actions", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
 
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,

--- a/test/RecipientAddrValidTransition.js
+++ b/test/RecipientAddrValidTransition.js
@@ -8,14 +8,14 @@ const testConstant = require('./helpers/testConstant');
 const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
-let userAddress = allAccounts[0];
-let recipientAddress = allAccounts[1];
-let signerAddress = allAccounts[2];
-let nonParticipantAddress = allAccounts[3];
+const userAddress = allAccounts[0];
+const recipientAddress = allAccounts[1];
+const signerAddress = allAccounts[2];
+const nonParticipantAddress = allAccounts[3];
 const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
 const userPk = Buffer.from(testConstant.USER_PK, 'hex');
 const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-var nonce = 1;
+let nonce = 1;
 
 contract("Valid Recipient Addresses", function () {
     beforeEach((done) => {
@@ -46,7 +46,6 @@ contract("Valid Recipient Addresses", function () {
                 MultiLibrary: {
                     args: [
                         '$ERC20Token',
-                        '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
                         signerAddress,
                         recipientAddress,
                         timeout,
@@ -140,9 +139,9 @@ contract("Valid Recipient Addresses", function () {
             from: userAddress
         });
         nonce++;
-        var amount = 49;
+        let amount = 49;
         const returnToken = false;
-        var cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+        let cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
 
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
             from: recipientAddress
@@ -178,16 +177,16 @@ contract("Valid Recipient Addresses", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, false).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, false).send({
             from: recipientAddress
         });
 
 
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,
@@ -269,16 +268,16 @@ contract("Valid Recipient Addresses", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, false).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, false).send({
             from: recipientAddress
         });
 
 
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,
@@ -360,18 +359,18 @@ contract("Valid Recipient Addresses", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        let validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
         nonce++;
-        amount = 50;
-        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        amount = 20;
+        validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
 
-        await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+        await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s).send({
             from: recipientAddress
         });
         const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
@@ -398,15 +397,15 @@ contract("Valid Recipient Addresses", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, false).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, false).send({
             from: recipientAddress
         });
 
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,
@@ -487,15 +486,15 @@ contract("Valid Recipient Addresses", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, false).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, false).send({
             from: recipientAddress
         });
 
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,

--- a/test/RecipientAddrValidTransition.js
+++ b/test/RecipientAddrValidTransition.js
@@ -54,7 +54,7 @@ config({
                 0,
                 0
             ],
-            "fromIndex": 1
+            "from": recipientAddress
         },
         "MultiChannel": {
             args: [

--- a/test/RecipientAddrValidTransition.js
+++ b/test/RecipientAddrValidTransition.js
@@ -2,330 +2,369 @@ const MultiChannel = require('Embark/contracts/MultiChannel');
 const ERC20Token = require('Embark/contracts/ERC20Token');
 const MultiLibrary = require('Embark/contracts/MultiLibrary');
 const indexes = require('./helpers/ChannelDataIndexes.js')
-const StandardToken = require('Embark/contracts/StandardToken.sol');
-const Token = require('Embark/contracts/Token.sol');
 const closingHelper = require('./helpers/channelClosingHelper');
 const assertRevert = require('./helpers/assertRevert');
 const testConstant = require('./helpers/testConstant');
-const allAccounts = testConstant.ACCOUNTS; 
+const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
+let userAddress = allAccounts[0];
+let recipientAddress = allAccounts[1];
+let signerAddress = allAccounts[2];
+let nonParticipantAddress = allAccounts[3];
 
 config({
     "deployment": {
-        "accounts": [
-            {
-                "mnemonic":testConstant.MNEMONIC,
-                "numAddresses":testConstant.NUM_ADDRESS,
-                "addressIndex": testConstant.INDEX,
-                "hdpath":testConstant.PATH
-            }
-        ]},
-        contracts: {
-            "Token": {
+        "accounts": [{
+            "mnemonic": testConstant.MNEMONIC,
+            "numAddresses": testConstant.NUM_ADDRESS,
+            "addressIndex": testConstant.INDEX,
+            "hdpath": testConstant.PATH
+        }]
+    },
+    contracts: {
+        "Token": {
 
-            },
-            "StandardToken": {
+        },
+        "StandardToken": {
 
-            },
-            "WETHToken": {
-                args:[initialCreation, "WETH", 18, "STK"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ThingToken": {
-                args:[initialCreation, "Thing", 18, "THG"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ERC20Token": {
-                args: [initialCreation,'STK', 18, 'STK'],
-                "from": allAccounts[3]
-            },
-            MultiLibrary: {
-                args: [
-                    '$ERC20Token',
-                    '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
-                    allAccounts[2],
-                    allAccounts[1],
-                    timeout,
-                    1,
-                    0,
-                    0
-                ],
-                "fromIndex":1
-            },
-            "MultiChannel": {
-                args: [
-                    allAccounts[0],
-                    allAccounts[2],
-                    '$ERC20Token',
-                    timeout
-                ],
-                "from": allAccounts[1]
-            }
+        },
+        "WETHToken": {
+            args: [initialCreation, "WETH", 18, "STK"],
+            "instanceOf": "ERC20Token",
+            "from": nonParticipantAddress
+        },
+        "ThingToken": {
+            args: [initialCreation, "Thing", 18, "THG"],
+            "instanceOf": "ERC20Token",
+            "from": nonParticipantAddress
+        },
+        "ERC20Token": {
+            args: [initialCreation, 'STK', 18, 'STK'],
+            "from": nonParticipantAddress
+        },
+        MultiLibrary: {
+            args: [
+                '$ERC20Token',
+                '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
+                signerAddress,
+                recipientAddress,
+                timeout,
+                1,
+                0,
+                0
+            ],
+            "fromIndex": 1
+        },
+        "MultiChannel": {
+            args: [
+                userAddress,
+                signerAddress,
+                '$ERC20Token',
+                timeout
+            ],
+            "from": recipientAddress
         }
+    }
+});
+
+contract("Testing Valid Recipient Transactions", function () {
+    this.timeout(0);
+    const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
+    const userPk = Buffer.from(testConstant.USER_PK, 'hex');
+    const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
+    const recipientAddressPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
+    var nonce = 1;
+
+
+    it("Multi Channel balance should be 50 after transferring 50 tokens", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        const initialCreatorBalance = await ERC20Token.methods.balanceOf(nonParticipantAddress).call();
+        const stkchannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+        assert.equal(stkchannelBalance.valueOf(), transfer, "MultiChannel should have 50 tokens after transfer but does not");
+        assert.equal(initialCreatorBalance.valueOf(), (initialCreation - transfer).valueOf(), "Initial creator should have transferred amount of tokens removed from account");
+    })
+
+    it("Recipient Address should be allowed to close the channel with a valid signature just under amount deposited", async () => {
+        nonce++;
+        const amount = 49;
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
+            from: recipientAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
     });
 
-    contract("Testing Valid Recipient Transactions", function () {
-        this.timeout(0);
-        let userAddress = allAccounts[0]; 
-        let recipientAddress= allAccounts[1]; 
-        let signerAddress = allAccounts[2]; 
-        const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
-        const userPk = Buffer.from(testConstant.USER_PK,'hex');
-        const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-        const recipientAddressPk = Buffer.from(testConstant.RECIPIENT_PK,'hex');
-        var nonce = 1;
+    it("Recipient Address should be allowed to contest the channel with valid signature equal to amount deposited", async () => {
+        nonce++;
+        const amount = 50;
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
 
-
-        it("Multi Channel balance should be 50 after transferring 50 tokens",async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-            const initialCreatorBalance = await ERC20Token.methods.balanceOf(allAccounts[3]).call();
-            const stkchannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-            assert.equal(stkchannelBalance.valueOf(), transfer, "MultiChannel should have 50 tokens after transfer but does not");
-            assert.equal(initialCreatorBalance.valueOf(), (initialCreation-transfer).valueOf(), "Initial creator should have transferred amount of tokens removed from account");
-        })
-
-        it("Recipient Address should be allowed to close the channel with a valid signature just under amount deposited", async() =>
-        {
-            nonce++;
-            const amount = 49;
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.options.address,signersPk);
-
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,returnToken).send({from:recipientAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
+        await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+            from: recipientAddress
         });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
 
-        it("Recipient Address should be allowed to contest the channel with valid signature equal to amount deposited", async() =>
-        {
-            nonce++;
-            const amount = 50;
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
 
-            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:recipientAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        });
-
-        it("Recipient Address should be able to settle after time period with 0 tokens remaining in channel", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }
-
-            const oldUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-            const dataBefore  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-            const oldStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const amountOwed = dataBefore[indexes.AMOUNT_OWED];
-            const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-            await MultiChannel.methods.settle(ERC20Token.options.address).send({from:allAccounts[1]});
-            const dataAfter  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const newUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const newStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-
-            assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf())>0,"Amount owed before settling should be greater than 0");
-            assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed after settling should be 0");
-            assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()),parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()),"closed nonce should not have been reset on settle");
-            assert.equal(parseInt(newStackBalance.valueOf()),parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The stack account value should be credited');
-            assert.equal(parseInt(newChannelBalance.valueOf()),parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
-            assert.equal(parseInt(newUserBalance.valueOf()),parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
-        });
-
-        it("Recipient Address should be allowed to close the channel with a valid signature less than amount deposited", async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-            nonce++;
-            const amount = 20;
-
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,returnToken).send({from:recipientAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        });
-
-        it("Recipient Address should be allowed to settle channel with additional tokens remaining in the channel", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }
-
-            const oldUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-            const dataBefore  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-            const oldStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const amountOwed = dataBefore[indexes.AMOUNT_OWED];
-            const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-            await MultiChannel.methods.settle(ERC20Token.options.address).send({from:allAccounts[1]});
-            const dataAfter  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const newUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const newStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-
-            assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf())>0,"Amount owed before settling should be greater than 0");
-            assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed after settling should be 0");
-            assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()),parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()),"closed nonce should not have been reset on settle");
-            assert.equal(parseInt(newStackBalance.valueOf()),parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The stack account value should be credited');
-            assert.equal(parseInt(newChannelBalance.valueOf()),parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
-            assert.equal(parseInt(newUserBalance.valueOf()),parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
-        });
-
-
-        it("Recipient Address can close a channel with just under deposited", async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});            
-            nonce++;
-            const amount = 49;
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.options.address,signersPk);
-
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,returnToken).send({from:recipientAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        });
-
-        it("Recipient Address can update closed channel with amount equivalent to deposited", async() =>
-        {
-            nonce++;
-            const amount = 50;
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,signersPk);
-
-            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:recipientAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        });
-
-        it("Recipient Address can settle with funds returned back to user", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }
-
-            const oldUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-            const dataBefore  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-            const oldStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const amountOwed = dataBefore[indexes.AMOUNT_OWED];
-            const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-            await MultiChannel.methods.settle(ERC20Token.options.address).send({from:allAccounts[1]});
-            const dataAfter  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const newUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const newStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-
-            assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf())>0,"Amount owed before settling should be greater than 0");
-            assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed after settling should be 0");
-            assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()),parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()),"closed nonce should not have been reset on settle");
-            assert.equal(parseInt(newStackBalance.valueOf()),parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The stack account value should be credited');
-            assert.equal(parseInt(newChannelBalance.valueOf()),parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
-            assert.equal(parseInt(newUserBalance.valueOf()),parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
-        });
-
-        it ("Recipient Address can close channel with amount just under deposited", async () => 
-        { 
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});                        
-            nonce++;
-            const amount = 49;
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.options.address,signersPk);
-
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,returnToken).send({from:recipientAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        }); 
-
-        it("Recipient Address can settle channel with funds returned", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }
-
-            const oldUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-            const dataBefore  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-            const oldStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const amountOwed = dataBefore[indexes.AMOUNT_OWED];
-            const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-            await MultiChannel.methods.settle(ERC20Token.options.address).send({from:allAccounts[1]});
-            const dataAfter  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const newUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const newStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-
-            assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf())>0,"Amount owed before settling should be greater than 0");
-            assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed after settling should be 0");
-            assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()),parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()),"closed nonce should not have been reset on settle");
-            assert.equal(parseInt(newStackBalance.valueOf()),parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The stack account value should be credited');
-            assert.equal(parseInt(newChannelBalance.valueOf()),parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
-            assert.equal(parseInt(newUserBalance.valueOf()),parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
-        });
-
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
     });
+
+    it("Recipient Address should be able to settle after time period with 0 tokens remaining in channel", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonParticipantAddress,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+
+        const oldUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+        const dataBefore = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+        const oldStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const amountOwed = dataBefore[indexes.AMOUNT_OWED];
+        const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+        await MultiChannel.methods.settle(ERC20Token.options.address).send({
+            from: recipientAddress
+        });
+        const dataAfter = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const newUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const newStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+
+        assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()) > 0, "Amount owed before settling should be greater than 0");
+        assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed after settling should be 0");
+        assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()), parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()), "closed nonce should not have been reset on settle");
+        assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The stack account value should be credited');
+        assert.equal(parseInt(newChannelBalance.valueOf()), parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
+        assert.equal(parseInt(newUserBalance.valueOf()), parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
+    });
+
+    it("Recipient Address should be allowed to close the channel with a valid signature less than amount deposited", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        nonce++;
+        const amount = 20;
+
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
+            from: recipientAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
+    });
+
+    it("Recipient Address should be allowed to settle channel with additional tokens remaining in the channel", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonParticipantAddress,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+
+        const oldUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+        const dataBefore = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+        const oldStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const amountOwed = dataBefore[indexes.AMOUNT_OWED];
+        const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+        await MultiChannel.methods.settle(ERC20Token.options.address).send({
+            from: recipientAddress
+        });
+        const dataAfter = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const newUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const newStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+
+        assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()) > 0, "Amount owed before settling should be greater than 0");
+        assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed after settling should be 0");
+        assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()), parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()), "closed nonce should not have been reset on settle");
+        assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The stack account value should be credited');
+        assert.equal(parseInt(newChannelBalance.valueOf()), parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
+        assert.equal(parseInt(newUserBalance.valueOf()), parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
+    });
+
+
+    it("Recipient Address can close a channel with just under deposited", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        nonce++;
+        const amount = 49;
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
+            from: recipientAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
+    });
+
+    it("Recipient Address can update closed channel with amount equivalent to deposited", async () => {
+        nonce++;
+        const amount = 50;
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+
+        await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+            from: recipientAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
+    });
+
+    it("Recipient Address can settle with funds returned back to user", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonParticipantAddress,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+
+        const oldUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+        const dataBefore = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+        const oldStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const amountOwed = dataBefore[indexes.AMOUNT_OWED];
+        const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+        await MultiChannel.methods.settle(ERC20Token.options.address).send({
+            from: recipientAddress
+        });
+        const dataAfter = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const newUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const newStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+
+        assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()) > 0, "Amount owed before settling should be greater than 0");
+        assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed after settling should be 0");
+        assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()), parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()), "closed nonce should not have been reset on settle");
+        assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The stack account value should be credited');
+        assert.equal(parseInt(newChannelBalance.valueOf()), parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
+        assert.equal(parseInt(newUserBalance.valueOf()), parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
+    });
+
+    it("Recipient Address can close channel with amount just under deposited", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonParticipantAddress
+        });
+        nonce++;
+        const amount = 49;
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
+            from: recipientAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
+    });
+
+    it("Recipient Address can settle channel with funds returned", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonParticipantAddress,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+
+        const oldUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+        const dataBefore = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+        const oldStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const amountOwed = dataBefore[indexes.AMOUNT_OWED];
+        const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+        await MultiChannel.methods.settle(ERC20Token.options.address).send({
+            from: recipientAddress
+        });
+        const dataAfter = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const newUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const newStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+
+        assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()) > 0, "Amount owed before settling should be greater than 0");
+        assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed after settling should be 0");
+        assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()), parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()), "closed nonce should not have been reset on settle");
+        assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The stack account value should be credited');
+        assert.equal(parseInt(newChannelBalance.valueOf()), parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
+        assert.equal(parseInt(newUserBalance.valueOf()), parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
+    });
+
+});

--- a/test/UserValidTransactions.js
+++ b/test/UserValidTransactions.js
@@ -8,14 +8,14 @@ const testConstant = require('./helpers/testConstant');
 const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
-let userAddress = allAccounts[0];
-let recipientAddress = allAccounts[1];
-let signerAddress = allAccounts[2];
-let nonParticipantAddress = allAccounts[3];
+const userAddress = allAccounts[0];
+const recipientAddress = allAccounts[1];
+const signerAddress = allAccounts[2];
+const nonParticipantAddress = allAccounts[3];
 const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
 const userPk = Buffer.from(testConstant.USER_PK, 'hex');
 const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-var nonce = 1;
+let nonce = 1;
 
 contract("Valid Transactions Made by User", function () {
     beforeEach((done) => {
@@ -139,10 +139,10 @@ contract("Valid Transactions Made by User", function () {
         await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
             from: userAddress
         });
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
@@ -177,16 +177,16 @@ contract("Valid Transactions Made by User", function () {
             from: userAddress
         });
         nonce++;
-        var amount = 49;
+        let amount = 49;
         const returnToken = false;
-        var cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+        let cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
 
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
             from: recipientAddress
         });
 
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,
@@ -235,9 +235,9 @@ contract("Valid Transactions Made by User", function () {
             from: userAddress
         });
         nonce++;
-        var amount = 20;
+        let amount = 20;
         const returnToken = false;
-        var cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+        let cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
 
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
             from: recipientAddress
@@ -267,16 +267,16 @@ contract("Valid Transactions Made by User", function () {
             from: userAddress
         });
         nonce++;
-        var amount = 49;
+        let amount = 49;
         const returnToken = false;
-        var cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+        let cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
 
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
             from: recipientAddress
         });
                 
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,
@@ -326,9 +326,9 @@ contract("Valid Transactions Made by User", function () {
             from: userAddress
         });
         nonce++;
-        var amount = 49;
+        let amount = 49;
         const returnToken = false;
-        var cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+        let cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
 
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
             from: recipientAddress
@@ -357,9 +357,9 @@ contract("Valid Transactions Made by User", function () {
             from: userAddress
         });
         nonce++;
-        var amount = 49;
+        let amount = 49;
         const returnToken = false;
-        var cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+        let cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
 
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
             from: recipientAddress
@@ -396,16 +396,16 @@ contract("Valid Transactions Made by User", function () {
             from: userAddress
         });
         nonce++;
-        var amount = 49;
+        let amount = 49;
         const returnToken = false;
-        var cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
+        let cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, signersPk);
 
         await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
             from: recipientAddress
         });
                         
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,
@@ -454,15 +454,15 @@ contract("Valid Transactions Made by User", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
-        const properClose = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
-        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, properClose.v, properClose.r, properClose.s, true).send({
+        const validSig = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, signersPk);
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, validSig.v, validSig.r, validSig.s, true).send({
             from: recipientAddress
         });
 
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,
@@ -527,14 +527,14 @@ contract("Valid Transactions Made by User", function () {
             from: userAddress
         });
 
-        var amount = 2;
+        let amount = 2;
 
         await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({
             from: userAddress
         });
 
         for (i = 0; i <= timeout; i++) {
-            var transaction = {
+            let transaction = {
                 from: nonParticipantAddress,
                 to: userAddress,
                 gasPrice: 1000000000,

--- a/test/UserValidTransactions.js
+++ b/test/UserValidTransactions.js
@@ -48,7 +48,7 @@ config({
                 0,
                 0
             ],
-            "fromIndex": 1
+            "from": recipientAddress
         },
         "MultiChannel": {
             args: [

--- a/test/UserValidTransactions.js
+++ b/test/UserValidTransactions.js
@@ -1,368 +1,410 @@
-
 const MultiChannel = require('Embark/contracts/MultiChannel');
 const ERC20Token = require('Embark/contracts/ERC20Token');
 const MultiLibrary = require('Embark/contracts/MultiLibrary');
 const indexes = require('./helpers/ChannelDataIndexes.js')
-const StandardToken = require('Embark/contracts/StandardToken.sol');
-const Token = require('Embark/contracts/Token.sol');
 const closingHelper = require('./helpers/channelClosingHelper');
 const assertRevert = require('./helpers/assertRevert');
 const testConstant = require('./helpers/testConstant');
-const allAccounts = testConstant.ACCOUNTS; 
+const allAccounts = testConstant.ACCOUNTS;
 const initialCreation = testConstant.INIT;
 const timeout = testConstant.TIMEOUT;
+let userAddress = allAccounts[0];
+let recipientAddress = allAccounts[1];
+let signerAddress = allAccounts[2];
+let nonChannelParticipant = allAccounts[3];
 
 config({
     "deployment": {
-        "accounts": [
-            {
-                "mnemonic":testConstant.MNEMONIC,
-                "numAddresses":testConstant.NUM_ADDRESS,
-                "addressIndex": testConstant.INDEX,
-                "hdpath":testConstant.PATH
-            }
-        ]},
-        contracts: {
-            "Token": {
-
-            },
-            "StandardToken": {
-
-            },
-            "WETHToken": {
-                args:[initialCreation, "WETH", 18, "STK"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ThingToken": {
-                args:[initialCreation, "Thing", 18, "THG"],
-                "instanceOf": "ERC20Token",
-                "from": allAccounts[3]
-            },
-            "ERC20Token": {
-                args: [initialCreation,'STK', 18, 'STK'],
-                "from": allAccounts[3]
-            },
-            MultiLibrary: {
-                args: [
-                    '$ERC20Token',
-                    '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
-                    allAccounts[2],
-                    allAccounts[1],
-                    timeout,
-                    1,
-                    0,
-                    0
-                ],
-                "fromIndex":1
-            },
-            "MultiChannel": {
-                args: [
-                    allAccounts[0],
-                    allAccounts[2],
-                    '$ERC20Token',
-                    timeout
-                ],
-                "from": allAccounts[1]
-            }
+        "accounts": [{
+            "mnemonic": testConstant.MNEMONIC,
+            "numAddresses": testConstant.NUM_ADDRESS,
+            "addressIndex": testConstant.INDEX,
+            "hdpath": testConstant.PATH
+        }]
+    },
+    contracts: {
+        "WETHToken": {
+            args: [initialCreation, "WETH", 18, "STK"],
+            "instanceOf": "ERC20Token",
+            "from": nonChannelParticipant
+        },
+        "ThingToken": {
+            args: [initialCreation, "Thing", 18, "THG"],
+            "instanceOf": "ERC20Token",
+            "from": nonChannelParticipant
+        },
+        "ERC20Token": {
+            args: [initialCreation, 'STK', 18, 'STK'],
+            "from": nonChannelParticipant
+        },
+        MultiLibrary: {
+            args: [
+                '$ERC20Token',
+                '0xC6eA7fD8628672780dd4F17Ffda321AA6753134B',
+                signerAddress,
+                recipientAddress,
+                timeout,
+                1,
+                0,
+                0
+            ],
+            "fromIndex": 1
+        },
+        "MultiChannel": {
+            args: [
+                userAddress,
+                signerAddress,
+                '$ERC20Token',
+                timeout
+            ],
+            "from": recipientAddress
         }
+    }
+});
+
+contract("Testing Valid Transactions made by User", function () {
+    this.timeout(0);
+    const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
+    const userPk = Buffer.from(testConstant.USER_PK, 'hex');
+    const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
+    const recipientAddressPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
+    var nonce = 1;
+
+    it("Multi Channel balance should be 50 after transferring 50 tokens", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonChannelParticipant
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonChannelParticipant
+        });
+        const initialCreatorBalance = await ERC20Token.methods.balanceOf(nonChannelParticipant).call();
+        const stkchannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+        assert.equal(stkchannelBalance.valueOf(), transfer, "MultiChannel should have 50 tokens after transfer but does not");
+        assert.equal(initialCreatorBalance.valueOf(), (initialCreation - transfer).valueOf(), "Initial creator should have transferred amount of tokens removed from account");
+    })
+
+    it("User should be allowed to close the channel with a valid signature just under amount deposited", async () => {
+        nonce++;
+        const amount = 49;
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, recipientAddressPk);
+
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
+            from: userAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
     });
 
-    contract("Testing Valid Transactions made by User", function () {
-        this.timeout(0);
-        let userAddress = allAccounts[0]; 
-        let recipientAddress= allAccounts[1]; 
-        let signerAddress = allAccounts[2]; 
-        const signersPk = Buffer.from(testConstant.SIGNER_PK, 'hex');
-        const userPk = Buffer.from(testConstant.USER_PK,'hex');
-        const recipientPk = Buffer.from(testConstant.RECIPIENT_PK, 'hex');
-        const recipientAddressPk = Buffer.from(testConstant.RECIPIENT_PK,'hex');
-        var nonce = 1;
+    it("User should be allowed to contest the channel with valid signature equal to amount deposited", async () => {
+        nonce++;
+        const amount = 50;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, recipientPk);
 
-        it("Multi Channel balance should be 50 after transferring 50 tokens",async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-            const initialCreatorBalance = await ERC20Token.methods.balanceOf(allAccounts[3]).call();
-            const stkchannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-            assert.equal(stkchannelBalance.valueOf(), transfer, "MultiChannel should have 50 tokens after transfer but does not");
-            assert.equal(initialCreatorBalance.valueOf(), (initialCreation-transfer).valueOf(), "Initial creator should have transferred amount of tokens removed from account");
-        })
-
-        it("User should be allowed to close the channel with a valid signature just under amount deposited", async() =>
-        {
-            nonce++;
-            const amount = 49;
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.options.address,recipientAddressPk);
-
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,returnToken).send({from:userAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
+        await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+            from: userAddress
         });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
 
-        it("User should be allowed to contest the channel with valid signature equal to amount deposited", async() =>
-        {
-            nonce++;
-            const amount = 50;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.options.address,recipientPk);
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
 
-            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:userAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        });
-
-        it("User should be able to settle after time period with 0 tokens remaining in channel", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }
-
-            const oldUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-            const dataBefore  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-            const oldStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const amountOwed = dataBefore[indexes.AMOUNT_OWED];
-            const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-            await MultiChannel.methods.settle(ERC20Token.options.address).send({from:allAccounts[1]});
-            const dataAfter  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const newUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const newStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-
-            assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf())>0,"Amount owed before settling should be greater than 0");
-            assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed after settling should be 0");
-            assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()),parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()),"closed nonce should not have been reset on settle");
-            assert.equal(parseInt(newStackBalance.valueOf()),parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
-            assert.equal(parseInt(newChannelBalance.valueOf()),parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
-            assert.equal(parseInt(newUserBalance.valueOf()),parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
-        });
-
-        it("User should be allowed to close the channel with a valid signature less than amount deposited", async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-            nonce++;
-            const amount = 20;
-
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,recipientAddressPk);
-
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,returnToken).send({from:userAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        });
-
-        it("User should be allowed to settle channel with additional tokens remaining in the channel", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }
-
-            const oldUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-            const dataBefore  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-            const oldStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const amountOwed = dataBefore[indexes.AMOUNT_OWED];
-            const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-            await MultiChannel.methods.settle(ERC20Token.options.address).send({from:allAccounts[1]});
-            const dataAfter  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const newUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const newStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-
-            assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf())>0,"Amount owed before settling should be greater than 0");
-            assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed after settling should be 0");
-            assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()),parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()),"closed nonce should not have been reset on settle");
-            assert.equal(parseInt(newStackBalance.valueOf()),parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
-            assert.equal(parseInt(newChannelBalance.valueOf()),parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
-            assert.equal(parseInt(newUserBalance.valueOf()),parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
-        });
-
-
-        it("User can close a channel with just under deposited", async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-            nonce++;
-            const amount = 49;
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.options.address,recipientAddressPk);
-
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,returnToken).send({from:userAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        });
-
-        it("User can update closed channel with amount equivalent to deposited", async() =>
-        {
-            nonce++;
-            const amount = 50;
-            const returnToken = false;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.address,recipientPk);
-
-            await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({from:userAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        });
-
-        it("User can settle with funds returned back to user", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }
-
-            const oldUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-            const dataBefore  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-            const oldStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const amountOwed = dataBefore[indexes.AMOUNT_OWED];
-            const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-            await MultiChannel.methods.settle(ERC20Token.options.address).send({from:allAccounts[1]});
-            const dataAfter  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const newUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const newStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-
-
-            assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf())>0,"Amount owed before settling should be greater than 0");
-            assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed after settling should be 0");
-            assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()),parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()),"closed nonce should not have been reset on settle");
-            assert.equal(parseInt(newStackBalance.valueOf()),parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
-            assert.equal(parseInt(newChannelBalance.valueOf()),parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
-            assert.equal(parseInt(newUserBalance.valueOf()),parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
-        });
-
-        it ("User can close channel with amount just under deposited", async () =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-            nonce++;
-            const amount = 49;
-            const returnToken = true;
-            const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address,nonce,amount,MultiChannel.options.address,recipientAddressPk);
-
-            await MultiChannel.methods.close(ERC20Token.options.address,nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s,returnToken).send({from:userAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const closedNonce = data[indexes.CLOSED_NONCE];
-            const closedBlock = data[indexes.CLOSED_BLOCK];
-
-            assert.equal(parseInt(closedNonce),nonce,"Nonces should be equal");
-            assert.notEqual(parseInt(closedBlock),0,"Closed block should not be set to 0");
-        });
-
-        it("User can settle channel with funds returned", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }
-            const dataBefore  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-            const oldStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const oldUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const amountOwed = dataBefore[indexes.AMOUNT_OWED];
-
-            await MultiChannel.methods.settle(ERC20Token.options.address).send({from:allAccounts[1]});
-            const dataAfter  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const newUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const newStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-
-            assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf())>0,"Amount owed before settling should be equal to 0");
-            assert.strictEqual(dataBefore[indexes.SHOULD_RETURN],true,"Should return_token should have been set to true");
-            assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf())>0,"Amount owed before settling should be greater than 0");
-            assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed after settling should be 0");
-            assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()),parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()),"closed nonce should not have been reset on settle");
-            assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
-            assert.equal(parseInt(newUserBalance.valueOf()),parseInt(oldUserBalance.valueOf()) + parseInt(depositedTokens.valueOf()) - parseInt(amountOwed.valueOf()),'The User address should get back the unused tokens');
-        });
-
-        it("User can close without signature if no IOUs exist", async() =>
-        {
-            const transfer = 50;
-            await ERC20Token.methods.approve(MultiChannel.options.address,transfer).send({from: allAccounts[3]});
-            await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({from: allAccounts[3]});
-
-            await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({from:userAddress});
-            const data  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            assert.strictEqual(data[indexes.SHOULD_RETURN],true,"Close without signature should set retunToken to true");
-            assert(data[indexes.CLOSED_BLOCK]>0, "closed block should be greater than 0");
-        });
-
-        it("User settling funds must return after closeWithoutSig", async() =>
-        {
-            for (i = 0; i<=timeout; i++)
-            {
-                var transaction = {from:allAccounts[7],to:allAccounts[8],gasPrice:1000000000,value:2};
-                web3.eth.sendTransaction(transaction);
-            }
-            const dataBefore  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
-            const oldStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-            const oldUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const amountOwed = dataBefore[indexes.AMOUNT_OWED];
-
-            await MultiChannel.methods.settle(ERC20Token.options.address).send({from:allAccounts[1]});
-            const dataAfter  = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
-
-            const newUserBalance = await ERC20Token.methods.balanceOf(allAccounts[0]).call();
-            const newStackBalance = await ERC20Token.methods.balanceOf(allAccounts[1]).call();
-
-            assert.strictEqual(dataBefore[indexes.SHOULD_RETURN],true,"Should return_token should have been set to true");
-            assert.strictEqual(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed before settling should be equal to 0");
-            assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()),0,"Amount owed after settling should be 0");
-            assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()),parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()),"closed nonce should not have been reset on settle");
-            assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
-            assert.equal(parseInt(newUserBalance.valueOf()),parseInt(oldUserBalance.valueOf()) + parseInt(depositedTokens.valueOf()) - parseInt(amountOwed.valueOf()),'The User address should get back the unused tokens');
-        });
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
     });
+
+    it("User should be able to settle after time period with 0 tokens remaining in channel", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonChannelParticipant,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+
+        const oldUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+        const dataBefore = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+        const oldStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const amountOwed = dataBefore[indexes.AMOUNT_OWED];
+        const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+        await MultiChannel.methods.settle(ERC20Token.options.address).send({
+            from: recipientAddress
+        });
+        const dataAfter = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const newUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const newStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+
+        assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()) > 0, "Amount owed before settling should be greater than 0");
+        assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed after settling should be 0");
+        assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()), parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()), "closed nonce should not have been reset on settle");
+        assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
+        assert.equal(parseInt(newChannelBalance.valueOf()), parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
+        assert.equal(parseInt(newUserBalance.valueOf()), parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
+    });
+
+    it("User should be allowed to close the channel with a valid signature less than amount deposited", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonChannelParticipant
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonChannelParticipant
+        });
+        nonce++;
+        const amount = 20;
+
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, recipientAddressPk);
+
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
+            from: userAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
+    });
+
+    it("User should be allowed to settle channel with additional tokens remaining in the channel", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonChannelParticipant,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+
+        const oldUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+        const dataBefore = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+        const oldStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const amountOwed = dataBefore[indexes.AMOUNT_OWED];
+        const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+        await MultiChannel.methods.settle(ERC20Token.options.address).send({
+            from: recipientAddress
+        });
+        const dataAfter = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const newUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const newStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+
+        assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()) > 0, "Amount owed before settling should be greater than 0");
+        assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed after settling should be 0");
+        assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()), parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()), "closed nonce should not have been reset on settle");
+        assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
+        assert.equal(parseInt(newChannelBalance.valueOf()), parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
+        assert.equal(parseInt(newUserBalance.valueOf()), parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
+    });
+
+
+    it("User can close a channel with just under deposited", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonChannelParticipant
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonChannelParticipant
+        });
+        nonce++;
+        const amount = 49;
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, recipientAddressPk);
+
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
+            from: userAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
+    });
+
+    it("User can update closed channel with amount equivalent to deposited", async () => {
+        nonce++;
+        const amount = 50;
+        const returnToken = false;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.address, recipientPk);
+
+        await MultiChannel.methods.updateClosedChannel(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s).send({
+            from: userAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
+    });
+
+    it("User can settle with funds returned back to user", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonChannelParticipant,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+
+        const oldUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+        const dataBefore = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+        const oldStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const amountOwed = dataBefore[indexes.AMOUNT_OWED];
+        const oldChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+        await MultiChannel.methods.settle(ERC20Token.options.address).send({
+            from: recipientAddress
+        });
+        const dataAfter = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const newUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const newStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const newChannelBalance = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+
+
+        assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()) > 0, "Amount owed before settling should be greater than 0");
+        assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed after settling should be 0");
+        assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()), parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()), "closed nonce should not have been reset on settle");
+        assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
+        assert.equal(parseInt(newChannelBalance.valueOf()), parseInt(oldChannelBalance.valueOf()) - parseInt(amountOwed.valueOf()), 'Unspent token should remain in the channel account');
+        assert.equal(parseInt(newUserBalance.valueOf()), parseInt(oldUserBalance.valueOf()), 'The User address account value should remain the same');
+    });
+
+    it("User can close channel with amount just under deposited", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: nonChannelParticipant
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: nonChannelParticipant
+        });
+        nonce++;
+        const amount = 49;
+        const returnToken = true;
+        const cryptoParams = closingHelper.getClosingParameters(ERC20Token.options.address, nonce, amount, MultiChannel.options.address, recipientAddressPk);
+
+        await MultiChannel.methods.close(ERC20Token.options.address, nonce, amount, cryptoParams.v, cryptoParams.r, cryptoParams.s, returnToken).send({
+            from: userAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const closedNonce = data[indexes.CLOSED_NONCE];
+        const closedBlock = data[indexes.CLOSED_BLOCK];
+
+        assert.equal(parseInt(closedNonce), nonce, "Nonces should be equal");
+        assert.notEqual(parseInt(closedBlock), 0, "Closed block should not be set to 0");
+    });
+
+    it("User can settle channel with funds returned", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonChannelParticipant,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+        const dataBefore = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+        const oldStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const oldUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const amountOwed = dataBefore[indexes.AMOUNT_OWED];
+
+        await MultiChannel.methods.settle(ERC20Token.options.address).send({
+            from: recipientAddress
+        });
+        const dataAfter = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const newUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const newStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+
+        assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()) > 0, "Amount owed before settling should be equal to 0");
+        assert.strictEqual(dataBefore[indexes.SHOULD_RETURN], true, "Should return_token should have been set to true");
+        assert.ok(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()) > 0, "Amount owed before settling should be greater than 0");
+        assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed after settling should be 0");
+        assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()), parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()), "closed nonce should not have been reset on settle");
+        assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
+        assert.equal(parseInt(newUserBalance.valueOf()), parseInt(oldUserBalance.valueOf()) + parseInt(depositedTokens.valueOf()) - parseInt(amountOwed.valueOf()), 'The User address should get back the unused tokens');
+    });
+
+    it("User can close without signature if no IOUs exist", async () => {
+        const transfer = 50;
+        await ERC20Token.methods.approve(MultiChannel.options.address, transfer).send({
+            from: signerAddress
+        });
+        await ERC20Token.methods.transfer(MultiChannel.options.address, transfer).send({
+            from: signerAddress
+        });
+
+        await MultiChannel.methods.closeWithoutSignature(ERC20Token.options.address).send({
+            from: userAddress
+        });
+        const data = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        assert.strictEqual(data[indexes.SHOULD_RETURN], true, "Close without signature should set retunToken to true");
+        assert(data[indexes.CLOSED_BLOCK] > 0, "closed block should be greater than 0");
+    });
+
+    it("User settling funds must return after closeWithoutSig", async () => {
+        for (i = 0; i <= timeout; i++) {
+            var transaction = {
+                from: nonChannelParticipant,
+                to: userAddress,
+                gasPrice: 1000000000,
+                value: 2
+            };
+            web3.eth.sendTransaction(transaction);
+        }
+        const dataBefore = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const depositedTokens = await ERC20Token.methods.balanceOf(MultiChannel.options.address).call();
+        const oldStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+        const oldUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const amountOwed = dataBefore[indexes.AMOUNT_OWED];
+
+        await MultiChannel.methods.settle(ERC20Token.options.address).send({
+            from: recipientAddress
+        });
+        const dataAfter = await MultiChannel.methods.getChannelData(ERC20Token.options.address).call();
+
+        const newUserBalance = await ERC20Token.methods.balanceOf(userAddress).call();
+        const newStackBalance = await ERC20Token.methods.balanceOf(recipientAddress).call();
+
+        assert.strictEqual(dataBefore[indexes.SHOULD_RETURN], true, "Should return_token should have been set to true");
+        assert.strictEqual(parseInt(dataBefore[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed before settling should be equal to 0");
+        assert.strictEqual(parseInt(dataAfter[indexes.AMOUNT_OWED].valueOf()), 0, "Amount owed after settling should be 0");
+        assert.strictEqual(parseInt(dataBefore[indexes.CLOSED_NONCE].valueOf()), parseInt(dataAfter[indexes.CLOSED_NONCE].valueOf()), "closed nonce should not have been reset on settle");
+        assert.equal(parseInt(newStackBalance.valueOf()), parseInt(oldStackBalance.valueOf()) + parseInt(amountOwed.valueOf()), 'The recipientAddress account value should be credited');
+        assert.equal(parseInt(newUserBalance.valueOf()), parseInt(oldUserBalance.valueOf()) + parseInt(depositedTokens.valueOf()) - parseInt(amountOwed.valueOf()), 'The User address should get back the unused tokens');
+    });
+});

--- a/test/helpers/assertRevert.js
+++ b/test/helpers/assertRevert.js
@@ -1,13 +1,6 @@
 /* https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/test/helpers/assertRevert.js */
 
 module.exports = function(error) {
-  async promise => {
-    try {
-      await promise;
-      assert.fail('Expected revert not received');
-    } catch (error) {
       const revertFound = error.message.search('revert') >= 0;
       assert(revertFound, `Expected "revert", got ${error} instead`);
     }
-  };
-}


### PR DESCRIPTION
 - Fixed javascript indentation 
 - Moved declaration of addresses to global scope in the contract 
 - Refactored `allAccounts[index]` to address name 
 - Changed parameters of `updateClosedChannel` and `close` tests 
 - Changed all tests to re-instantiate a new instantiation of all required Solidity Contracts 
 - assertRevert finally works now