### PR TITLE
Implemented IOU functionality for deposit function and tests

### DIFF
--- a/contracts/MultiChannel.sol
+++ b/contracts/MultiChannel.sol
@@ -147,8 +147,21 @@ contract MultiChannel
         channels[_addressOfToken].addChannel(_from, _addressOfSigner, _expiryNumberOfBlocks);
     }
 
+    /**
+    * @notice Allowing ETH deposits to the channel address
+     */
     function() public payable {
     }
+
+    /** @notice After ETH deposit is made via fallback function, deposit is called using signed transaction by signer address by recipient or user
+    * @param _addressOfWETH The specific address of WETH to deposit to
+    * @param _nonce For deposit signatures, expected to be 0
+    * @param _amount For deposit amount, expected to be 0
+    * @param _v Cryptographic param v derived from signature
+    * @param _r Cryptographic param r derived from signature
+    * @param _s Cryptographic param s derived from signature
+    * @param gasAmount Amount of gas to use to deposit ETh into channel
+     */
 
     function deposit(
         address _addressOfWETH,

--- a/contracts/MultiChannel.sol
+++ b/contracts/MultiChannel.sol
@@ -34,8 +34,6 @@ contract MultiChannel
     event LogChannelClosed(uint blockNumber, address closer, uint amount);
     event LogDeposited(address depositingAddress, uint amount);
     event LogChannelContested(uint amount, address caller);
-    event Deposit(uint amount);
-
     /**
      * @dev Contract constructor
      * @param _from The user address in the contract.
@@ -152,13 +150,18 @@ contract MultiChannel
     function() public payable {
     }
 
-    function deposit(address _addressOfWETH, uint gasAmount)
+    function deposit(
+        address _addressOfWETH,
+        uint _nonce,
+        uint _amount,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s,
+        uint gasAmount)
     external
     channelExists(_addressOfWETH)
     {
-        require(recipientAddress == msg.sender || channels[_addressOfWETH].userAddress_ == msg.sender);
-        require(_addressOfWETH.call.value(address(this).balance).gas(gasAmount)());
-        emit Deposit(address(this).balance);
+        channels[_addressOfWETH].deposit(_addressOfWETH, _nonce, _amount, _v, _r, _s, gasAmount);
     }
 
     /**

--- a/contracts/MultiLibrary.sol
+++ b/contracts/MultiLibrary.sol
@@ -31,7 +31,8 @@ library MultiLibrary {
     }
 
     event LogChannelSettled(uint blockNumber, uint finalBalance);
-    event CloseTest(address addr);
+    event Deposit(uint amount);
+
 
     modifier channelAlreadyClosed(MultiChannelData storage data) {
         require(data.closedBlock_ > 0);
@@ -60,6 +61,25 @@ library MultiLibrary {
     modifier isSufficientBalance(MultiChannelData storage data, uint amount, address channelAddress) {
         require(amount <= data.token_.balanceOf(channelAddress));
         _;
+    }
+
+    function deposit(
+        MultiChannelData storage data,
+        address _addressOfWETH,
+        uint _nonce,
+        uint _amount,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s,
+        uint gasAmount
+    )
+    public
+    callerIsChannelParticipant(data)
+    {
+        address signerAddress = recoverAddressFromHashAndParameters(_addressOfWETH, _nonce, _amount, _r, _s, _v);
+        require(signerAddress == data.signerAddress_);
+        require (_addressOfWETH.call.value(address(this).balance).gas(gasAmount)());
+        emit Deposit(address(this).balance);
     }
 
     /**

--- a/contracts/MultiLibrary.sol
+++ b/contracts/MultiLibrary.sol
@@ -63,6 +63,17 @@ library MultiLibrary {
         _;
     }
 
+    /** @notice Function to deposit funds into WETH payment channel with user authentication
+    * @param data The channel specific data to work on.
+    * @param _addressOfWETH The specific address of WETH to deposit to
+    * @param _nonce For deposit signatures, expected to be 0
+    * @param _amount For deposit amount, expected to be 0
+    * @param _v Cryptographic param v derived from signature
+    * @param _r Cryptographic param r derived from signature
+    * @param _s Cryptographic param s derived from signature
+    * @param gasAmount Amount of gas to use to deposit ETh into channel
+     */
+
     function deposit(
         MultiChannelData storage data,
         address _addressOfWETH,

--- a/test/TestWETH.js
+++ b/test/TestWETH.js
@@ -175,7 +175,7 @@ contract("Testing WETH", function () {
         assert.equal(tokenContract, 1000000000000000000, "WETH should have 1 ETH balance");
     });
 
-    it("Non Channel Participant should be able to convert ETH to WETH with signer-signed signature", async () => {
+    it("Non Channel Participant should not be able to convert ETH to WETH with signer-signed signature", async () => {
         await MultiChannel.methods.addChannel(WETH.options.address, userAddress, signerAddress, timeout).send({
             from: recipientAddress
         });


### PR DESCRIPTION
 - Requires IOU in order to call deposit from a transaction signed by the signer's private key 
 - Added additional tests: 
    ✓ Recipient should be able to convert ETH to WETH with signer-signed signature 
    ✓ User should not be able to convert ETH to WETH with self-signed signature 
    ✓ User should be able to convert ETH to WETH with signer-signed signature 
    ✓ Recipient should not be able to convert ETH to WETH with self-signed signature
    ✓ User should not be able to convert ETH to WETH with recipient-signed signature