### PR TITLE
Removed redundant signer address require

### DIFF
--- a/contracts/MultiLibrary.sol
+++ b/contracts/MultiLibrary.sol
@@ -120,7 +120,6 @@ library MultiLibrary {
     isSufficientBalance(data, _amount, address(this)) {
         address signerAddress = recoverAddressFromHashAndParameters(_addressOfToken, _nonce, _amount, _r, _s, _v);
         require((signerAddress == data.signerAddress_ && data.recipientAddress_ == msg.sender) || (signerAddress == data.recipientAddress_ && data.userAddress_ == msg.sender));
-        require(signerAddress != msg.sender);
         require(data.closedNonce_ < _nonce);
         data.amountOwed_ = _amount;
         data.closedNonce_ = _nonce;


### PR DESCRIPTION
 - MultiLibrary had a redundant `require (msg.sender != signerAddress)`, which was not serving any purpose, as we already had a modifier for `callerIsChannelParticipant()`