### PR TITLE
Removed transferFrom function in WETH

### DIFF
--- a/contracts/WETH.sol
+++ b/contracts/WETH.sol
@@ -95,24 +95,6 @@ contract WETH {
         dst.transfer(wad);
         emit Transfer(src, dst, wad);
     }
-
-    function transferFrom(address src, address dst, uint wad)
-    public
-    returns(bool) {
-        require(balances[src] >= wad);
-
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
-            require(allowance[src][msg.sender] >= wad);
-            allowance[src][msg.sender] -= wad;
-        }
-
-        balances[src] -= wad;
-        balances[dst] += wad;
-
-        emit Transfer(src, dst, wad);
-
-        return true;
-    }
 }
 
 


### PR DESCRIPTION
 - Removed `transferFrom` function in WETH, as it is not being used 
 - Functionality: To transfer WETH to different users 