### PR TITLE
Changed require to == 

### DIFF
--- a/contracts/MultiChannel.sol
+++ b/contracts/MultiChannel.sol
@@ -20,7 +20,7 @@ contract MultiChannel
 
     modifier channelDoesNotExist(address addressOfToken)
     {
-        require(channels[addressOfToken].timeout_ <= uint(0));
+        require(channels[addressOfToken].timeout_ == uint(0));
         _;
     }
 


### PR DESCRIPTION
`uint` cannot contain negative values, so there was no point checking whether `timeout` is <= 0. 